### PR TITLE
Require errors

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,4 @@
+var errors = require('./errors');
 var validRe = /^[\w-]+$/;
 
 


### PR DESCRIPTION
utils.js was attempting to reference `errors` without requiring it.