### PR TITLE
Prevent hanging of test runner when ran it via gulp-mocha

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,10 @@ gulp.task('lint', function() {
 // run the mocha tests
 gulp.task('mocha', function () {
     return gulp.src('./test/integration/index.js', {read: false})
-        .pipe(mocha());
+        .pipe(mocha())
+        .once('end', function () {
+            process.exit();
+        });
 });
 
 // run the mocha tests


### PR DESCRIPTION
This commit follows the advice at https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting