### PR TITLE
Special build parameters for frontend builds in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
   "main": "./src/getstream.js",
   "homepage": "https://getstream.io/",
   "version": "2.2.2",
+  "browser": {
+    "request": "browser-request",
+    "faye": "./node_modules/faye/faye-browser.js",
+    "crypto": false,
+    "jsonwebtoken": false
+  },
   "config": {
     "blanket": {
       "pattern": "src"
@@ -41,6 +47,7 @@
   },
   "license": "BSD",
   "dependencies": {
+    "browser-request": "^0.3.3",
     "faye": "^1.0.1",
     "jsonwebtoken": "^5.0.1",
     "request": "2.63.0"


### PR DESCRIPTION
As discussed in #50 package.json should take care of frontend build specific parameters for users using the library through a build tool chain and require.