### PR TITLE
Added createRedirectUrl to client and fixed timestamp issue on JWT's

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "request": "browser-request",
     "crypto": false,
     "jsonwebtoken": false,
-    "./src/lib/batch_operations.js": false
+    "./src/lib/batch_operations.js": false,
+    "qs": false,
+    "url": false
   },
   "config": {
     "blanket": {
@@ -58,6 +60,7 @@
     "faye": "^1.0.1",
     "http-signature": "^1.0.2",
     "jsonwebtoken": "^5.0.1",
+    "qs": "^5.2.0",
     "request": "2.63.0"
   },
   "repository": {

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -54,3 +54,17 @@ errors.SiteError = function SiteError(msg) {
 };
 
 errors.SiteError.prototype = new ErrorAbstract();
+
+/**
+ * MissingSchemaError
+ * @method MissingSchema
+ * @access private
+ * @extends ErrorAbstract
+ * @memberof Stream.errors
+ * @param  {string} msg
+ */
+errors.MissingSchemaError = function MissingSchemaError(msg) {
+  ErrorAbstract.call(this, msg);
+};
+
+errors.MissingSchemaError.prototype = new ErrorAbstract();

--- a/src/lib/signing.js
+++ b/src/lib/signing.js
@@ -81,18 +81,47 @@ exports.sign = function(apiSecret, feedId) {
   return token;
 };
 
-exports.JWTScopeToken = function(apiSecret, feedId, resource, action) {
-  /*
+exports.JWTScopeToken = function(apiSecret, resource, action, opts) {
+  /**
    * Creates the JWT token for feedId, resource and action using the apiSecret
+   * @method JWTScopeToken
+   * @memberof signing
+   * @private
+   * @param {string} apiSecret - API Secret key
+   * @param {string} resource - JWT payload resource
+   * @param {string} action - JWT payload action
+   * @param {object} [options] - Optional additional options
+   * @param {string} [options.feedId] - JWT payload feed identifier
+   * @param {string} [options.userId] - JWT payload user identifier
+   * @return {string} JWT Token
    */
-  var payload = {'feed_id':feedId, resource:resource, action:action};
-  var token = jwt.sign(payload, apiSecret, {algorithm: 'HS256'});
+  var options = opts || {},
+      noTimestamp = options.noTimestamp || true;
+  var payload = {
+    resource: resource,
+    action: action,
+  };
+
+  if (options.feedId) {
+    payload['feed_id'] = options.feedId;
+  }
+
+  if (options.userId) {
+    payload['user_id'] = options.userId;
+  }
+
+  var token = jwt.sign(payload, apiSecret, {algorithm: 'HS256', noTimestamp: noTimestamp});
   return token;
 };
 
 exports.isJWTSignature = function(signature) {
-  /*
+  /**
    * check if token is a valid JWT token
+   * @method isJWTSignature
+   * @memberof signing
+   * @private
+   * @param {string} signature - Signature to check
+   * @return {boolean}
    */
   var token = signature.split(' ')[1];
   return JWS_REGEX.test(token) && !!headerFromJWS(token);

--- a/src/lib/signing.js
+++ b/src/lib/signing.js
@@ -96,7 +96,7 @@ exports.JWTScopeToken = function(apiSecret, resource, action, opts) {
    * @return {string} JWT Token
    */
   var options = opts || {},
-      noTimestamp = options.noTimestamp || true;
+      noTimestamp = options.expireTokens ? !options.expireTokens : true;
   var payload = {
     resource: resource,
     action: action,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -47,3 +47,10 @@ function validateUserId(userId) {
 
 exports.validateUserId = validateUserId;
 
+function rfc3986(str) {
+  return str.replace(/[!'()*]/g, function(c) {
+    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+  });
+}
+
+exports.rfc3986 = rfc3986;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,9 +1,12 @@
 var expect = require('expect.js');
 var jwt = require('jsonwebtoken');
+var url = require('url');
+var qs = require('qs');
 var qc = require('quickcheck');
 var utils = require('../../src/lib/utils');
 var errors = require('../../src/lib/errors');
-var node = typeof(window) === 'undefined';
+var node = typeof window === 'undefined';
+var stream = require('../../src/getstream');
 
 var signing = signing || require('../../src/lib/signing');
 
@@ -74,4 +77,43 @@ describe('Utility functions', function() {
       expect(e).to.be.a(errors.FeedError);
     });
   });
+});
+
+describe('Stream Client', function() {
+  var client = stream.connect('ahj2ndz7gsan', 'gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy');
+
+  it('should create email redirects', function() {
+    var expectedParts = ['https://analytics.getstream.io/analytics/redirect/',
+      'auth_type=jwt',
+      'url=http%3A%2F%2Fgoogle.com%2F%3Fa%3Db%26c%3Dd',
+      'events=%5B%7B%22foreign_ids%22%3A%5B%22tweet%3A1%22%2C%22tweet%3A2%22%2C%22tweet%3A3%22%2C%22tweet%3A4%22%2C%22tweet%3A5%22%5D%2C%22user_id%22%3A%22tommaso%22%2C%22location%22%3A%22email%22%2C%22feed_id%22%3A%22user%3Aglobal%22%7D%2C%7B%22foreign_id%22%3A%22tweet%3A1%22%2C%22label%22%3A%22click%22%2C%22position%22%3A3%2C%22user_id%22%3A%22tommaso%22%2C%22location%22%3A%22email%22%2C%22feed_id%22%3A%22user%3Aglobal%22%7D%5D',
+      'api_key=ahj2ndz7gsan',
+    ];
+    var engagement = { 'foreign_id': 'tweet:1', 'label': 'click', 'position': 3, 'user_id': 'tommaso', 'location': 'email', 'feed_id': 'user:global' },
+        impression = {'foreign_ids': ['tweet:1', 'tweet:2', 'tweet:3', 'tweet:4', 'tweet:5'], 'user_id': 'tommaso', 'location': 'email', 'feed_id': 'user:global'},
+        events = [impression, engagement],
+        userId = 'tommaso',
+        targetUrl = 'http://google.com/?a=b&c=d';
+    var redirectUrl = client.createRedirectUrl(targetUrl, userId, events);
+
+    var queryString = qs.parse(url.parse(redirectUrl).query);
+    var decoded = jwt.verify(queryString.authorization, 'gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy');
+
+    expect(decoded).to.eql({
+      'resource': 'redirect_and_track',
+      'action': '*',
+      'user_id': userId,
+    });
+
+    for (var i = 0; i < expectedParts.length; i++) {
+      expect(redirectUrl).to.contain(expectedParts[i]);
+    }
+  });
+
+  it('should fail creating email redirects on invalid targets', function() {
+    expect(function() {
+      client.createRedirectUrl('google.com', 'tommaso', []);
+    }).to.throwException(errors.MissingSchemaError);
+  });
+
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ module.exports = {
         crypto: 'empty',
         fs: 'empty',
         net: 'empty',
-        tls: 'empty'
+        tls: 'empty',
+        url: 'empty'
     },
     resolve: {
       alias: {
@@ -32,5 +33,5 @@ module.exports = {
         { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"}
       ]
     },
-    plugins: [new webpack.NormalModuleReplacementPlugin(/(jsonwebtoken|http-signature|batch_operations)/, path.join(__dirname, "src", "/missing.js"))]
+    plugins: [new webpack.NormalModuleReplacementPlugin(/(jsonwebtoken|http-signature|batch_operations|qs)/, path.join(__dirname, "src", "/missing.js"))]
 };


### PR DESCRIPTION
#61 and #58 both fixed. Used 'qs' library to create querystring. createRedirectUrl fails on incorrect targetUrl (similar to python implementation. Created two tests to test createRedirectUrl one to check whether wrong target urls result in an error and one to test the result. Notice that I decode the resulting JWT and check that result, instead of checking against an encoded JWT (like the python lib does). That is a bad idea because the order of the payload json affects the encoded JWT making the test really prone to failures (that do not origin from anything actually breaking) especially since dicts do not have a true ordering. Maybe a good idea to change this test in the py lib as well.