### PR TITLE
Explitely disable withCredentials

### DIFF
--- a/src/lib/batch_operations.js
+++ b/src/lib/batch_operations.js
@@ -78,6 +78,9 @@ module.exports = {
       kwargs.json = true;
       kwargs.method = 'POST';
       kwargs.headers = { 'X-Api-Key': this.apiKey };
+      // Make sure withCredentials is not enabled, different browser
+      // fallbacks handle it differently by default (meteor)
+      kwargs.withCredentials = false;
 
       var callback = this.wrapPromiseTask(cb, fulfill, reject);
       var req = request(kwargs, callback);

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -321,6 +321,9 @@ StreamClient.prototype = {
 
     kwargs.headers.Authorization = signature;
     kwargs.headers['X-Stream-Client'] = this.userAgent();
+    // Make sure withCredentials is not enabled, different browser
+    // fallbacks handle it differently by default (meteor)
+    kwargs.withCredentials = false;
     return kwargs;
   },
 


### PR DESCRIPTION
This fixes #99, because meteor uses its own request fallback, instead of the
one here: https://github.com/matthisk/xmlhttp-request