### PR TITLE
Feat/update dot com domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
-sudo: false
 language: node_js
+
 node_js:
-- 0.12
-- 4
-- 5
-- 6
+  - node
+  - 8
+  - 6
+  - 4
+
 env:
 - BROWSER_TESTS="no"
+
 matrix:
  include:
- - node_js: 6.8
+ - node_js: 8.4
    env: BROWSER_TESTS="yes"
+
 script:
 - if [ "$BROWSER_TESTS" == "no" ]; then bash ./bin/travis.sh; fi
 - if [ "$BROWSER_TESTS" == "yes" ]; then npm run test-browser-ci; fi
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ subscription.cancel();
 
 Docs are available on [GetStream.io](http://getstream.io/docs/?language=js).
 
+#### Node version requirements & Browser support
 
+This API Client project requires Node.js v0.11.0 at a minimum.
+
+The project is supported in line with the Node.js Foundation Release Working Group.
+
+See the [Travis configuration](.travis.yml) and [Sauce Test Status](https://saucelabs.com/u/tthisk) for details of how it is built, tested and packaged.
 
 Contributing
 ------------

--- a/src/getstream.js
+++ b/src/getstream.js
@@ -36,7 +36,7 @@ function connect(apiKey, apiSecret, appId, options) {
       options = {};
     }
 
-    if (location !== 'getstream') {
+    if (location !== 'getstream' && location !== 'stream-io-api') {
       options.location = location;
     }
   }

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -28,7 +28,7 @@ var StreamClient = function() {
 
 StreamClient.prototype = {
   baseUrl: 'https://api.stream-io-api.com/api/',
-  baseAnalyticsUrl: 'https://analytics.getstream.io/analytics/',
+  baseAnalyticsUrl: 'https://analytics.stream-io-api.com/analytics/',
 
   initialize: function(apiKey, apiSecret, appId, options) {
     /**
@@ -60,9 +60,9 @@ StreamClient.prototype = {
     this.expireTokens = this.options.expireTokens ? this.options.expireTokens : false;
     // which data center to use
     this.location = this.options.location;
-    
+
     var protocol = this.options.protocol || 'https';
-    
+
     if (this.location) {
         this.baseUrl = protocol + '://' + this.location + '-api.stream-io-api.com/api/';
     }
@@ -77,6 +77,10 @@ StreamClient.prototype = {
 
     if (typeof (process) !== 'undefined' && process.env.STREAM_BASE_URL) {
       this.baseUrl = process.env.STREAM_BASE_URL;
+    }
+
+    if (typeof (process) !== 'undefined' && process.env.STREAM_ANALYTICS_BASE_URL) {
+      this.baseAnalyticsUrl = process.env.STREAM_ANALYTICS_BASE_URL;
     }
 
     this.handlers = {};
@@ -492,13 +496,13 @@ StreamClient.prototype = {
       signature: authToken,
     }, callback);
   },
-  
+
   updateActivity: function(activity) {
     /**
      * Updates one activity on the getstream-io api
      * @since  3.1.0
      * @param  {object} activity The activity to update
-     * @return {Promise}          
+     * @return {Promise}
      */
      return this.updateActivities([activity]);
   },
@@ -517,7 +521,7 @@ if (qs) {
      * @param  {string} userId    User id to track
      * @param  {array} events     List of events to track
      * @return {string}           The redirect url
-     */    
+     */
     var uri = url.parse(targetUrl);
 
     if (!(uri.host || (uri.hostname && uri.port)) && !uri.isUnix) {

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -27,7 +27,7 @@ var StreamClient = function() {
 };
 
 StreamClient.prototype = {
-  baseUrl: 'https://api.getstream.io/api/',
+  baseUrl: 'https://api.stream-io-api.com/api/',
   baseAnalyticsUrl: 'https://analytics.getstream.io/analytics/',
 
   initialize: function(apiKey, apiSecret, appId, options) {
@@ -64,7 +64,7 @@ StreamClient.prototype = {
     var protocol = this.options.protocol || 'https';
     
     if (this.location) {
-        this.baseUrl = protocol + '://' + this.location + '-api.getstream.io/api/';
+        this.baseUrl = protocol + '://' + this.location + '-api.stream-io-api.com/api/';
     }
 
     if (typeof (process) !== 'undefined' && process.env.LOCAL) {

--- a/test/integration/utils/hooks.js
+++ b/test/integration/utils/hooks.js
@@ -52,9 +52,9 @@ function initBrowser() {
 function beforeEachNode() {
     this.client = stream.connect(config.API_KEY, config.API_SECRET);
     this.client = stream.connect(config.API_KEY, config.API_SECRET, config.APP_ID, {
-        'group': 'testCycle', 
+        'group': 'testCycle',
         'location': 'qa',
-        'protocol': 'http',
+        'protocol': 'https',
     });
     this.user1 = this.client.feed('user', randUserId('11'));
     this.user2 = this.client.feed('user', randUserId('22'));
@@ -72,9 +72,9 @@ function beforeEachNode() {
 function beforeEachBrowser() {
     this.client = stream.connect(config.API_KEY);
     this.client = stream.connect(config.API_KEY, null, config.APP_ID, {
-        'group': 'browserTestCycle', 
+        'group': 'browserTestCycle',
         'location': 'qa',
-        'protocol': 'http',
+        'protocol': 'https',
     });
 
     if (this.localRun){

--- a/test/unit/browser/client_test.js
+++ b/test/unit/browser/client_test.js
@@ -38,7 +38,7 @@ describe('[UNIT] Stream Client (browser)', function() {
 
         expect(client.version).to.be('v2.0');
         expect(client.expireTokens).to.be(true);
-        expect(client.baseUrl).to.be('https://nederland-api.getstream.io/api/');
+        expect(client.baseUrl).to.be('https://nederland-api.stream-io-api.com/api/');
         expect(client.fayeUrl).to.be('https://hello.world');
     });
 

--- a/test/unit/common/client_test.js
+++ b/test/unit/common/client_test.js
@@ -26,7 +26,7 @@ describe('[UNIT] Stream Client (Common)', function() {
         expect(this.client.group).to.be('unspecified');
         expect(this.client.location).to.be(undefined);
         expect(this.client.expireTokens).to.be(false);
-        expect(this.client.baseUrl).to.be('https://api.getstream.io/api/');
+        expect(this.client.baseUrl).to.be('https://api.stream-io-api.com/api/');
     });
 
     describe('#on', function() {

--- a/test/unit/node/client_test.js
+++ b/test/unit/node/client_test.js
@@ -118,7 +118,7 @@ describe('[UNIT] Stream Client (Node)', function() {
             var client = stream.connect('12345', 'abcdefghijklmnop', null, {
                 location: 'nl-NL'
             });
-            expect(client.baseUrl).to.be('https://nl-NL-api.getstream.io/api/');
+            expect(client.baseUrl).to.be('https://nl-NL-api.stream-io-api.com/api/');
         });
 
         it('#LOCAL_FAYE', function() {
@@ -131,10 +131,10 @@ describe('[UNIT] Stream Client (Node)', function() {
         });
 
         it('#STREAM_BASE_URL', function() {
-            process.env['STREAM_BASE_URL'] = 'http://local.getstream.io/api/';
+            process.env['STREAM_BASE_URL'] = 'http://local.stream-io-api.com/api/';
 
             var client = stream.connect('12345', 'abcdefghijklmnop');
-            expect(client.baseUrl).to.be('http://local.getstream.io/api/');
+            expect(client.baseUrl).to.be('http://local.stream-io-api.com/api/');
 
             delete process.env['STREAM_BASE_URL'];
         });

--- a/test/unit/node/client_test.js
+++ b/test/unit/node/client_test.js
@@ -131,10 +131,10 @@ describe('[UNIT] Stream Client (Node)', function() {
         });
 
         it('#STREAM_BASE_URL', function() {
-            process.env['STREAM_BASE_URL'] = 'http://local.stream-io-api.com/api/';
+            process.env['STREAM_BASE_URL'] = 'https://local.stream-io-api.com/api/';
 
             var client = stream.connect('12345', 'abcdefghijklmnop');
-            expect(client.baseUrl).to.be('http://local.stream-io-api.com/api/');
+            expect(client.baseUrl).to.be('https://local.stream-io-api.com/api/');
 
             delete process.env['STREAM_BASE_URL'];
         });

--- a/test/unit/node/heroku_test.js
+++ b/test/unit/node/heroku_test.js
@@ -1,51 +1,113 @@
-var beforeEach = require('../utils/hooks').beforeEach
+var beforeEachFn = require('../utils/hooks').beforeEach
+  , init = require('../utils/hooks').init
   , stream = require('../../../src/getstream')
   , expect = require('expect.js');
 
 describe('[UNIT] Stream client (Heroku)', function() {
 
-    beforeEach(beforeEach);
+    init.call(this);
+    beforeEach(beforeEachFn);
 
-    it('heroku', function(done) {
-        var url = 'https://thierry:pass@getstream.io/?app_id=1';
-        process.env.STREAM_URL = url;
-        this.client = stream.connect();
-        expect(this.client.apiKey).to.eql('thierry');
-        expect(this.client.apiSecret).to.eql('pass');
-        expect(this.client.appId).to.eql('1');
-        done();
+    describe('#Heroku', function() {
+
+        it('heroku (stream-io-api.com)', function(done) {
+            var url = 'https://thierry:pass@stream-io-api.com/?app_id=1';
+            process.env.STREAM_URL = url;
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('thierry');
+            expect(this.client.apiSecret).to.eql('pass');
+            expect(this.client.appId).to.eql('1');
+            expect(this.client.baseUrl).to.eql('https://api.stream-io-api.com/api/');
+            delete process.env['STREAM_URL'];
+            done();
+        });
+
+        it('heroku (getstream.io)', function(done) {
+            var url = 'https://thierry:pass@getstream.io/?app_id=1';
+            process.env.STREAM_URL = url;
+            process.env.STREAM_BASE_URL = 'https://api.getstream.io/api/';
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('thierry');
+            expect(this.client.apiSecret).to.eql('pass');
+            expect(this.client.appId).to.eql('1');
+            expect(this.client.baseUrl).to.eql('https://api.getstream.io/api/');
+            delete process.env['STREAM_URL'];
+            delete process.env['STREAM_BASE_URL'];
+            done();
+        });
+
+        it('heroku legacy (stream-io-api.com)', function(done) {
+            var url = 'https://bvt88g4kvc63:twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd@stream-io-api.com/?app_id=669';
+            process.env.STREAM_URL = url;
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('bvt88g4kvc63');
+            expect(this.client.apiSecret).to.eql('twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd');
+            expect(this.client.appId).to.eql('669');
+            expect(this.client.baseUrl).to.eql('https://api.stream-io-api.com/api/');
+            delete process.env['STREAM_URL'];
+            done();
+        });
+
+        it('heroku legacy (getstream.io)', function(done) {
+            var url = 'https://bvt88g4kvc63:twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd@getstream.io/?app_id=669';
+            process.env.STREAM_URL = url;
+            process.env.STREAM_BASE_URL = 'https://api.getstream.io/api/';
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('bvt88g4kvc63');
+            expect(this.client.apiSecret).to.eql('twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd');
+            expect(this.client.appId).to.eql('669');
+            expect(this.client.baseUrl).to.eql('https://api.getstream.io/api/');
+            delete process.env['STREAM_URL'];
+            delete process.env['STREAM_BASE_URL'];
+            done();
+        });
+
+        it('heroku with location (stream-io-api.com)', function(done) {
+            var url = 'https://ahj2ndz7gsan:gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy@us-east.stream-io-api.com/?app_id=1';
+            process.env.STREAM_URL = url;
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('ahj2ndz7gsan');
+            expect(this.client.apiSecret).to.eql('gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy');
+            expect(this.client.appId).to.eql('1');
+            expect(this.client.baseUrl).to.eql('https://us-east-api.stream-io-api.com/api/');
+            delete process.env['STREAM_URL'];
+            done();
+        });
+
+        it('heroku with location (getstream.io)', function(done) {
+            var url = 'https://ahj2ndz7gsan:gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy@us-east.getstream.io/?app_id=1';
+            process.env.STREAM_URL = url;
+            process.env.STREAM_BASE_URL = 'https://us-east-api.getstream.io/api/';
+            this.client = stream.connect();
+            expect(this.client.apiKey).to.eql('ahj2ndz7gsan');
+            expect(this.client.apiSecret).to.eql('gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy');
+            expect(this.client.appId).to.eql('1');
+            expect(this.client.baseUrl).to.eql('https://us-east-api.getstream.io/api/');
+            delete process.env['STREAM_URL'];
+            delete process.env['STREAM_BASE_URL'];
+            done();
+        });
+
+        it('heroku_overwrite (stream-io-api.com)', function(done) {
+            var url = 'https://thierry:pass@stream-io-api.com/?app_id=1';
+            process.env.STREAM_URL = url;
+            this.client = stream.connect('a', 'b', 'c');
+            expect(this.client.apiKey).to.eql('a');
+            expect(this.client.apiSecret).to.eql('b');
+            expect(this.client.appId).to.eql('c');
+            delete process.env['STREAM_URL'];
+            done();
+        });
+
+        it('heroku_overwrite (getstream.io)', function(done) {
+            var url = 'https://thierry:pass@getstream.io/?app_id=1';
+            process.env.STREAM_URL = url;
+            this.client = stream.connect('a', 'b', 'c');
+            expect(this.client.apiKey).to.eql('a');
+            expect(this.client.apiSecret).to.eql('b');
+            expect(this.client.appId).to.eql('c');
+            delete process.env['STREAM_URL'];
+            done();
+        });
     });
-
-    it('heroku legacy', function(done) {
-        var url = 'https://bvt88g4kvc63:twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd@getstream.io/?app_id=669';
-        process.env.STREAM_URL = url;
-        this.client = stream.connect();
-        expect(this.client.apiKey).to.eql('bvt88g4kvc63');
-        expect(this.client.apiSecret).to.eql('twc5ywfste5bm2ngqkzs7ukxk3pn96yweghjrxcmcrarnt3j4dqj3tucbhym5wfd');
-        expect(this.client.appId).to.eql('669');
-        expect(this.client.baseUrl).to.eql('https://api.getstream.io/api/');
-        done();
-    });
-
-    it('heroku with location', function(done) {
-        var url = 'https://ahj2ndz7gsan:gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy@us-east.getstream.io/?app_id=1';
-        process.env.STREAM_URL = url;
-        this.client = stream.connect();
-        expect(this.client.apiKey).to.eql('ahj2ndz7gsan');
-        expect(this.client.apiSecret).to.eql('gthc2t9gh7pzq52f6cky8w4r4up9dr6rju9w3fjgmkv6cdvvav2ufe5fv7e2r9qy');
-        expect(this.client.appId).to.eql('1');
-        expect(this.client.baseUrl).to.eql('https://us-east-api.getstream.io/api/');
-        done();
-    });
-
-    it('heroku_overwrite', function(done) {
-        var url = 'https://thierry:pass@getstream.io/?app_id=1';
-        process.env.STREAM_URL = url;
-        this.client = stream.connect('a', 'b', 'c');
-        expect(this.client.apiKey).to.eql('a');
-        expect(this.client.apiSecret).to.eql('b');
-        expect(this.client.appId).to.eql('c');
-        done();
-    });
-
 });

--- a/test/unit/node/redirect_test.js
+++ b/test/unit/node/redirect_test.js
@@ -1,17 +1,61 @@
 var config = require('../utils/config')
+  , StreamClient = require('../utils/mocks').StreamClient
   , jwt = require('jsonwebtoken')
   , url = require('url')
   , request = require('request')
   , expect = require('expect.js')
+  , afterEachFn = require('../utils/hooks').afterEach
   , beforeEachFn = require('../utils/hooks').beforeEach
   , errors = require('../../../src/lib/errors')
   , qs = require('qs');
 
 describe('[UNIT] Redirect URL\'s', function() {
 
-    beforeEach(beforeEachFn);
+    // beforeEach(beforeEachFn);
 
-    it('should create email redirects', function() {
+    it('should create email redirects (analytics.stream-io-api.com)', function() {
+        var expectedParts = ['https://analytics.stream-io-api.com/analytics/redirect/',
+            'auth_type=jwt',
+            'url=http%3A%2F%2Fgoogle.com%2F%3Fa%3Db%26c%3Dd',
+            'events=%5B%7B%22foreign_ids%22%3A%5B%22tweet%3A1%22%2C%22tweet%3A2%22%2C%22tweet%3A3%22%2C%22tweet%3A4%22%2C%22tweet%3A5%22%5D%2C%22user_id%22%3A%22tommaso%22%2C%22location%22%3A%22email%22%2C%22feed_id%22%3A%22user%3Aglobal%22%7D%2C%7B%22foreign_id%22%3A%22tweet%3A1%22%2C%22label%22%3A%22click%22%2C%22position%22%3A3%2C%22user_id%22%3A%22tommaso%22%2C%22location%22%3A%22email%22%2C%22feed_id%22%3A%22user%3Aglobal%22%7D%5D',
+            'api_key=' + config.API_KEY,
+        ];
+        var engagement = {
+                'foreign_id': 'tweet:1',
+                'label': 'click',
+                'position': 3,
+                'user_id': 'tommaso',
+                'location': 'email',
+                'feed_id': 'user:global'
+            },
+            impression = {
+                'foreign_ids': ['tweet:1', 'tweet:2', 'tweet:3', 'tweet:4', 'tweet:5'],
+                'user_id': 'tommaso',
+                'location': 'email',
+                'feed_id': 'user:global'
+            },
+            events = [impression, engagement],
+            userId = 'tommaso',
+            targetUrl = 'http://google.com/?a=b&c=d';
+
+        this.client = new StreamClient(config.API_KEY, config.API_SECRET);
+        var redirectUrl = this.client.createRedirectUrl(targetUrl, userId, events);
+
+        var queryString = qs.parse(url.parse(redirectUrl).query);
+        var decoded = jwt.verify(queryString.authorization, config.API_SECRET);
+
+        expect(decoded).to.eql({
+            'resource': 'redirect_and_track',
+            'action': '*',
+            'user_id': userId,
+        });
+
+        for (var i = 0; i < expectedParts.length; i++) {
+            expect(redirectUrl).to.contain(expectedParts[i]);
+        }
+    });
+
+    it('should create email redirects (analytics.getstream.io)', function() {
         var expectedParts = ['https://analytics.getstream.io/analytics/redirect/',
             'auth_type=jwt',
             'url=http%3A%2F%2Fgoogle.com%2F%3Fa%3Db%26c%3Dd',
@@ -35,6 +79,8 @@ describe('[UNIT] Redirect URL\'s', function() {
             events = [impression, engagement],
             userId = 'tommaso',
             targetUrl = 'http://google.com/?a=b&c=d';
+        process.env.STREAM_ANALYTICS_BASE_URL = 'https://analytics.getstream.io/analytics/'
+        this.client = new StreamClient(config.API_KEY, config.API_SECRET);
         var redirectUrl = this.client.createRedirectUrl(targetUrl, userId, events);
 
         var queryString = qs.parse(url.parse(redirectUrl).query);
@@ -49,6 +95,7 @@ describe('[UNIT] Redirect URL\'s', function() {
         for (var i = 0; i < expectedParts.length; i++) {
             expect(redirectUrl).to.contain(expectedParts[i]);
         }
+        delete process.env['STREAM_ANALYTICS_BASE_URL']
     });
 
     it('should follow redirect urls', function(done) {

--- a/test/unit/utils/hooks.js
+++ b/test/unit/utils/hooks.js
@@ -8,22 +8,16 @@ function init() {
 }
 
 function beforeEachBrowser() {
-    this.client = stream.connect(config.API_KEY);
-    this.client = stream.connect(config.API_KEY, null, 9498);
-
-    this.client = new StreamClient(config.API_KEY);
-    this.client = new StreamClient(config.API_KEY, null, 9498);
+  this.client = new StreamClient(config.API_KEY, null, 9498);
 }
 
 function beforeEachNode() {
-    this.client = stream.connect(config.API_KEY, config.API_SECRET);
-    
-    this.client = new StreamClient(config.API_KEY, config.API_SECRET);
+  this.client = new StreamClient(config.API_KEY, config.API_SECRET);
 }
 
 module.exports = {
-    init: init,
-    beforeEachNode : beforeEachNode,
-    beforeEachBrowser : beforeEachBrowser,
-    beforeEach: config.IS_NODE_ENV ? beforeEachNode : beforeEachBrowser,
+  init: init,
+  beforeEachNode : beforeEachNode,
+  beforeEachBrowser : beforeEachBrowser,
+  beforeEach: config.IS_NODE_ENV ? beforeEachNode : beforeEachBrowser,
 };


### PR DESCRIPTION
## Stream API:

 - STREAM_URL - to continue to use STREAM_URL in the format 'https://thierry:pass@getstream.io/?app_id=1' (potentially used in older Heroku deployments), an additional STREAM_BASE_URL must be set. E.g. 'https://api.getstream.io/api/' (without our default location) or 'https://us-east-api.getstream.io/api/' (with a specific location).

## Stream Analytics:

  - To continue using the legacy 'https://analytics.getstream.io/analytics/' endpoint, set STREAM_ANALYTICS_BASE_URL environment variable.
