### PR TITLE
Fix a typo

### DIFF
--- a/docs/getstream/3.0.0/index.html
+++ b/docs/getstream/3.0.0/index.html
@@ -158,7 +158,7 @@ user1 = client.feed('user', '1', token);
 // creating a read-only feed token server side
 readonlyToken = client.getReadOnlyToken('user', '1');
 // passed to client via template or api and initialized as such
-user1 = client.feed('user', '1', readonlyToken);</code></pre><h3>Faye</h3><p>Stream uses Faye for realtime notifications. Below is quick quide to subcribing to feed changes</p>
+user1 = client.feed('user', '1', readonlyToken);</code></pre><h3>Faye</h3><p>Stream uses Faye for realtime notifications. Below is quick guide to subcribing to feed changes</p>
 <pre class="prettyprint source lang-javascript"><code>var stream = require('getstream');
 // NOTE: the site id is needed for subscribing
 // server side example:


### PR DESCRIPTION
### Changed

- `quick quide` -> `quick guide`