### PR TITLE
Add missing StreamApiError prototype

### DIFF
--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -68,6 +68,8 @@ errors.MissingSchemaError = function MissingSchemaError(msg) {
   ErrorAbstract.call(this, msg);
 };
 
+errors.MissingSchemaError.prototype = new ErrorAbstract();
+
 /**
  * StreamApiError
  * @method StreamApiError
@@ -85,4 +87,4 @@ errors.StreamApiError = function StreamApiError(msg, data, response) {
   ErrorAbstract.call(this, msg);
 };
 
-errors.MissingSchemaError.prototype = new ErrorAbstract();
+errors.StreamApiError.prototype = new ErrorAbstract();


### PR DESCRIPTION
Currently, `StreamApiError` does not correctly extend `Error`. This is because it is missing `Error` in its prototype.

This was the reason why so many stream errors appeared incorrectly for us in Sentry. Sentry will only extract the error message if the object is a subclass of `Error` (i.e. `instanceof Error === true`), otherwise it will stringify it, resulting in `"[object Object]"`.

![image](https://user-images.githubusercontent.com/921609/32112985-c4bb8a92-bb36-11e7-8955-e4cf0a9a26d3.png)

Related https://github.com/GetStream/stream-js/issues/119