### PR TITLE
Update userId validation message to say 'userId' instead of 'feedSlug'

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -39,7 +39,7 @@ function validateUserId(userId) {
   	 */
   var valid = validRe.test(userId);
   if (!valid) {
-    throw new errors.FeedError('Invalid feedSlug, please use letters, numbers or _ got: ' + userId);
+    throw new errors.FeedError('Invalid userId, please use letters, numbers or _ got: ' + userId);
   }
 
   return userId;


### PR DESCRIPTION
I passed an invalid userId and was very confused for a second that it was telling me my feedSlug was incorrect.