### PR TITLE
make options optional on follow operation

### DIFF
--- a/types/getstream/index.d.ts
+++ b/types/getstream/index.d.ts
@@ -46,7 +46,7 @@ declare class Feed {
   follow(
     targetSlug: string,
     targetUserId: string,
-    options: object
+    options?: object
   ): Promise<object>;
   follow(
     targetSlug: string,

--- a/types/getstream/tests-getstream.ts
+++ b/types/getstream/tests-getstream.ts
@@ -4,6 +4,8 @@ let c = new stream.Client("key", undefined, "apiSecret");
 
 stream.connect("abc", "def", "ghi"); // $ExpectType StreamClient
 
+stream.connect("abc", "def", "ghi").feed('feedSlug', 'user').follow('feedSlug', 'user')
+
 new stream.errors.MissingSchemaError(); // $ExpectType MissingSchemaError
 new stream.errors.FeedError(); // $ExpectType FeedError
 new stream.errors.SiteError(); // $ExpectType SiteError


### PR DESCRIPTION
Just a type change to allow omission of follow options as per docs https://getstream.io/docs/#following.

Requires `.follow(feed, user, {})` if no options otherwise