### PR TITLE
Bump node 'engines', exclude integration tests from Travis builds (2nd attempt)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - node
+  - 9
   - 8
   - 6
   - 4
@@ -11,7 +11,7 @@ env:
 
 matrix:
  include:
- - node_js: 8.4
+ - node_js: node
    env: BROWSER_TESTS="yes"
 
 script:

--- a/karma.config.js
+++ b/karma.config.js
@@ -37,8 +37,6 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-          'test/integration/browser/**/*_test.js',
-          'test/integration/common/**/*_test.js',
           'test/unit/common/**/*_test.js',
           'test/unit/browser/**/*_test.js',
         ],
@@ -52,8 +50,6 @@ module.exports = function(config) {
         preprocessors: {
             'test/unit/common/**/*_test.js': [ 'webpack', 'sourcemap' ],
             'test/unit/browser/**/*_test.js': [ 'webpack', 'sourcemap' ],
-            'test/integration/browser/**/*_test.js': [ 'webpack', 'sourcemap' ],
-            'test/integration/common/**/*_test.js': [ 'webpack', 'sourcemap' ],
         },
 
         // Webpack configuration for webpack preprocessor

--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "url": "git://github.com/GetStream/stream-js.git"
   },
   "engines": {
-    "node": ">=0.11 <=6.8"
+    "node": ">=4.8 <=9"
   }
 }


### PR DESCRIPTION
Updates travis build config to run browser tests on node 'latest' (currently 9.8.0).