### PR TITLE
Refactored to lazily generate personalization/collections tokens

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -90,21 +90,45 @@ StreamClient.prototype = {
       });
 
       this.requestAgent = this.baseUrl.startsWith('https://') ? httpsAgent : httpAgent;
-
-      // setup personalization and collections
-      this.personalizationToken = signing.JWTScopeToken(
-        this.apiSecret, 'personalization', '*', {userId: '*', feedId: '*', expireTokens: this.expireTokens });
-      this.collectionsToken = signing.JWTScopeToken(
-        this.apiSecret, 'collections', '*', {userId: '*', feedId: '*', expireTokens: this.expireTokens });
-
-      this.personalization = new Personalization(this);
-      this.collections = new Collections(this);
     }
+
+    this.personalization = new Personalization(this);
+    this.collections = new Collections(this);
 
     /* istanbul ignore next */
     if (this.browser && this.apiSecret) {
       throw new errors.FeedError('You are publicly sharing your App Secret. Do not expose the App Secret in browsers, "native" mobile apps, or other non-trusted environments.');
     }
+  },
+
+  getPersonalizationToken: function() {
+    if (this._personalizationToken) {
+      return this._personalizationToken;
+    }
+
+    if (this.apiSecret) {
+        this._personalizationToken = signing.JWTScopeToken(
+          this.apiSecret, 'personalization', '*', {userId: '*', feedId: '*', expireTokens: this.expireTokens });
+    } else {
+      throw new errors.SiteError('Missing secret, which is needed to perform signed requests, use var client = stream.connect(key, secret);');
+    }
+
+    return this._personalizationToken;
+  },
+
+  getCollectionsToken: function() {
+    if (this._collectionsToken) {
+      return this._collectionsToken;
+    }
+
+    if (this.apiSecret) {
+        this._collectionsToken = signing.JWTScopeToken(
+          this.apiSecret, 'collections', '*', {userId: '*', feedId: '*', expireTokens: this.expireTokens });
+    } else {
+      throw new errors.SiteError('Missing secret, which is needed to perform signed requests, use var client = stream.connect(key, secret);');
+    }
+
+    return this._collectionsToken;
   },
 
   getBaseUrl: function(serviceName) {

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -1,3 +1,5 @@
+var errors = require('./errors');
+
 var Collections = function() {
   /**
    * Manage api calls for collections
@@ -6,6 +8,7 @@ var Collections = function() {
    */
   this.initialize.apply(this, arguments);
 };
+
 
 Collections.prototype = {
   initialize: function(client) {
@@ -38,7 +41,7 @@ Collections.prototype = {
         url: 'meta/',
         serviceName: 'api',
         body: data_json,
-        signature: this.client.collectionsToken
+        signature: this.client.getCollectionsToken()
       },
       callback);
   },
@@ -70,7 +73,7 @@ Collections.prototype = {
         url: 'meta/',
         serviceName: 'api',
         qs: params,
-        signature: this.client.collectionsToken
+        signature: this.client.getCollectionsToken()
       },
       callback);
   },
@@ -105,7 +108,7 @@ Collections.prototype = {
         url: 'meta/',
         serviceName: 'api',
         qs: params,
-        signature: this.client.collectionsToken
+        signature: this.client.getCollectionsToken()
       },
       callback);
   },

--- a/src/lib/personalization.js
+++ b/src/lib/personalization.js
@@ -1,3 +1,5 @@
+var errors = require('./errors');
+
 var Personalization = function() {
   /**
    * Manage api calls for personalization
@@ -43,7 +45,7 @@ Personalization.prototype = {
         url: resource + '/',
         serviceName: 'personalization',
         qs: options,
-        signature: this.client.personalizationToken
+        signature: this.client.getPersonalizationToken()
       },
       callback);
   },
@@ -77,7 +79,7 @@ Personalization.prototype = {
         serviceName: 'personalization',
         qs: options,
         body: data,
-        signature: this.client.personalizationToken
+        signature: this.client.getPersonalizationToken()
       },
       callback);
   },
@@ -106,7 +108,7 @@ Personalization.prototype = {
         url: resource + '/',
         serviceName: 'personalization',
         qs: options,
-        signature: this.client.personalizationToken
+        signature: this.client.getPersonalizationToken()
       },
       callback);
   },

--- a/test/unit/node/client_test.js
+++ b/test/unit/node/client_test.js
@@ -3,8 +3,19 @@ var StreamFeed = require('../../../src/lib/feed'),
     beforeEachFn = require('../utils/hooks').beforeEach,
     td = require('testdouble'),
     stream = require('../../../src/getstream'),
-    signing = require('../../../src/lib/signing');
+    StreamClient = require('../../../src/lib/client');
 
+
+describe('[UNIT] Stream Client instantiation (Node)', function() {
+
+    it('with secret', function() {
+      new StreamClient('stub-key', 'stub-secret', 9498);
+    });
+
+    it('without secret', function() {
+        new StreamClient('stub-key', null, 9498);
+    });
+});
 
 describe('[UNIT] Stream Client (Node)', function() {
 

--- a/test/unit/node/personalization_test.js
+++ b/test/unit/node/personalization_test.js
@@ -1,9 +1,10 @@
 var expect = require('expect.js'),
     beforeEachFn = require('../utils/hooks').beforeEach,
+    errors = require('../../../src/getstream').errors,
     td = require('testdouble'),
     stream = require('../../../src/getstream'),
     signing = require('../../../src/lib/signing'),
-    Personalization = require('../../../src/lib/personalization');
+    StreamClient = require('../../../src/lib/client');
 
 
 describe('[UNIT] Stream Personalization (node)', function() {
@@ -29,7 +30,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var options = {foo: 'bar', baz: 'qux'};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.get(resource, options);
 
             td.verify(get({
@@ -46,7 +47,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var options = {foo: 'bar', baz: 'qux'};
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.get(resource, options, cb);
 
             td.verify(get({
@@ -62,7 +63,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var fakedJWT = "Faked JWT";
             var resource = 'example';
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.get(resource);
 
             td.verify(get({
@@ -78,7 +79,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.get(resource, cb);
 
             td.verify(get({
@@ -99,7 +100,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var data = {k: 'v'};
             var options = {foo: 'bar', baz: 'qux'};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource, options, data);
 
             td.verify(post({
@@ -118,7 +119,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var data = {k: 'v'};
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource, options, data, cb);
 
             td.verify(post({
@@ -136,7 +137,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var options = {foo: 'bar', baz: 'qux'};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource, options);
 
             td.verify(post({
@@ -154,7 +155,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var options = {foo: 'bar', baz: 'qux'};
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource, options, cb);
 
             td.verify(post({
@@ -172,7 +173,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var fakedJWT = "Faked JWT";
             var resource = 'example';
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource);
 
             td.verify(post({
@@ -189,7 +190,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.post(resource, cb);
 
             td.verify(post({
@@ -210,7 +211,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var options = {foo: 'bar', baz: 'qux'};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.delete(resource, options);
 
             td.verify(del({
@@ -227,7 +228,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var options = {foo: 'bar', baz: 'qux'};
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.delete(resource, options, cb);
 
             td.verify(del({
@@ -243,7 +244,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var fakedJWT = "Faked JWT";
             var resource = 'example';
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.delete(resource);
 
             td.verify(del({
@@ -259,7 +260,7 @@ describe('[UNIT] Stream Personalization (node)', function() {
             var resource = 'example';
             var cb = function() {};
 
-            this.client.personalizationToken = fakedJWT;
+            this.client._personalizationToken = fakedJWT;
             this.client.personalization.delete(resource, cb);
 
             td.verify(del({
@@ -271,4 +272,40 @@ describe('[UNIT] Stream Personalization (node)', function() {
                           callback=cb));
         });
     });
+
+
+    describe('No secret provided', function() {
+
+        it('should raise SiteErrors', function() {
+
+            var client = new StreamClient('stub-key', null, 9498);
+            var resource = 'example';
+            var options = {foo: 'bar', baz: 'qux'};
+            var data = {k: 'v'};
+            var cb = function() {};
+
+            // get
+            expect(function() {
+                client.personalization.get(resource, options);
+            }).to.throwException(function(e) {
+                expect(e).to.be.a(errors.SiteError);
+            });
+
+            // post
+            expect(function() {
+                client.personalization.post(resource, options, data, cb);
+            }).to.throwException(function(e) {
+                expect(e).to.be.a(errors.SiteError);
+            });
+
+            // delete
+            expect(function() {
+                client.personalization.delete(resource);
+            }).to.throwException(function(e) {
+                expect(e).to.be.a(errors.SiteError);
+            });
+
+        });
+    });
+
 });


### PR DESCRIPTION
Raise meaningful error if no API Secret was provided when the client was
initialised with the 'connect()' function.

Resolves #178 