### PR TITLE
Move @babel/runtime to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "getstream",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -781,6 +781,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
       "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -788,7 +789,8 @@
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "babel-loader": "^8.0.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.1",
@@ -98,7 +99,6 @@
     "webpack-cli": "^3.0.8"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
     "@stream-io/cross-fetch": "^3.0.1",
     "@stream-io/xmlhttp-request": "^0.4.0",
     "Base64": "^1.0.1",


### PR DESCRIPTION
It's only used when Babel builds code, so there's no need for it to be a production dependency.