### PR TITLE
remove response.statusCode in favor of response.status

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -419,7 +419,6 @@ class StreamClient {
       return response.data;
     }
 
-    response.statusCode = response.status; // maintained for backward compatibility
     throw new errors.StreamApiError(
       `${JSON.stringify(response.data)} with HTTP status code ${response.status}`,
       response.data,

--- a/test/integration/cloud/utils.js
+++ b/test/integration/cloud/utils.js
@@ -154,8 +154,8 @@ export class CloudContext {
     this.test(`the activity should ${label}`, fn);
   }
 
-  requestShouldError(statusCode, fn) {
-    this.test(`the request should error with status ${statusCode}`, async () => {
+  requestShouldError(status, fn) {
+    this.test(`the request should error with status ${status}`, async () => {
       try {
         await fn();
         expect.fail(null, null, 'request should not succeed');
@@ -163,10 +163,10 @@ export class CloudContext {
         if (!(e instanceof stream.errors.StreamApiError)) {
           throw e;
         }
-        if (e.response.statusCode !== statusCode) {
+        if (e.response.status !== status) {
           console.log(e.error); // eslint-disable-line no-console
         }
-        e.response.statusCode.should.equal(statusCode);
+        e.response.status.should.equal(status);
         this.error = e;
         this.response = e.error;
       }

--- a/test/integration/common/faye_test.js
+++ b/test/integration/common/faye_test.js
@@ -43,7 +43,7 @@ describe('[INTEGRATION] Stream client (Faye)', function () {
 
     const httpCallback = function (error, response, body) {
       if (error) done(error);
-      if (response.statusCode !== 201) done(body);
+      if (response.status !== 201) done(body);
     };
 
     Promise.all([
@@ -76,7 +76,7 @@ describe('[INTEGRATION] Stream client (Faye)', function () {
 
     const httpCallback = function (error, response, body) {
       if (error) done(error);
-      if (response.statusCode !== 201) done(body);
+      if (response.status !== 201) done(body);
     };
 
     const doneYet = function () {

--- a/test/unit/common/client_test.js
+++ b/test/unit/common/client_test.js
@@ -189,7 +189,7 @@ describe('[UNIT] Stream Client (Common)', function () {
       expect(() => this.client.handleResponse({ status: 400, data })).to.throwException((err) => {
         expect(err).to.be.a(errors.StreamApiError);
         expect(err.error).to.be.eql(data);
-        expect(err.response).to.be.eql({ status: 400, statusCode: 400, data });
+        expect(err.response).to.be.eql({ status: 400, data });
       });
     });
 
@@ -198,7 +198,7 @@ describe('[UNIT] Stream Client (Common)', function () {
       expect(() => this.client.handleResponse({ status: 500, data })).to.throwException((err) => {
         expect(err).to.be.a(errors.StreamApiError);
         expect(err.error).to.be.eql(data);
-        expect(err.response).to.be.eql({ status: 500, statusCode: 500, data });
+        expect(err.response).to.be.eql({ status: 500, data });
       });
     });
   });


### PR DESCRIPTION
Breaking change:
- `StreamApiError.response.statusCode` replaced with `StreamApiError.response.status`