### PR TITLE
Fix cannot turn off enrichment on client side.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -505,7 +505,7 @@ export class StreamClient<
     }
 
     return (
-      this.enrichByDefault ||
+      (this.enrichByDefault && options.enrich !== false) ||
       options.ownReactions != null ||
       options.withRecentReactions != null ||
       options.withReactionCounts != null ||


### PR DESCRIPTION
When running on client side mode (in browser), no api secret, we are not able to turn off enrichment.

fixes https://github.com/GetStream/stream-js/issues/380