### PR TITLE
README: yarn add not yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install getstream
 or if you are using yarn
 
 ```bash
-yarn install getstream
+yarn add getstream
 ```
 
 ### Using JS deliver


### PR DESCRIPTION
`yarn install getstream` gives an error

```
$ yarn install getstream
yarn install v1.22.4
error `install` has been replaced with `add` to add new dependencies. Run "yarn add getstream" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```