### PR TITLE
fix: type of itemId in collections add method

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -166,12 +166,12 @@ export class Collections<CollectionType extends UnknownRecord = UnknownRecord> {
    * @method add
    * @memberof Collections.prototype
    * @param  {string}   collection  collection name
-   * @param  {string}   itemId  entry id
+   * @param  {?string}   itemId  entry id
    * @param  {CollectionType}   itemData  ObjectStore data
    * @return {Promise<CollectionEntry<CollectionType>>}
    * @example collection.add("food", "cheese101", {"name": "cheese burger","toppings": "cheese"})
    */
-  async add(collection: string, itemId: string, itemData: CollectionType) {
+  async add(collection: string, itemId: string | null, itemData: CollectionType) {
     const response = await this.client.post<CollectionAPIResponse<CollectionType>>({
       url: this.buildURL(collection),
       body: {

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -166,7 +166,7 @@ export class Collections<CollectionType extends UnknownRecord = UnknownRecord> {
    * @method add
    * @memberof Collections.prototype
    * @param  {string}   collection  collection name
-   * @param  {?string}   itemId  entry id
+   * @param  {string | null}    itemId  entry id, if null a random id will be assigned to the item
    * @param  {CollectionType}   itemData  ObjectStore data
    * @return {Promise<CollectionEntry<CollectionType>>}
    * @example collection.add("food", "cheese101", {"name": "cheese burger","toppings": "cheese"})


### PR DESCRIPTION
According to the [documentation](https://getstream.io/docs/collections_introduction/?language=js) the `itemId` parameter in the collections `add()` method should be a string or `null`, so that it's possible to let stream generate an ID.

The current type of the parameter is set to `string`, which causes a TS compiler error when trying to add a collection item without an ID.

This PR updates the type to include `null` and updates the JSDoc accordingly