### PR TITLE
Fallback to supplied token

### DIFF
--- a/src/feed.ts
+++ b/src/feed.ts
@@ -467,7 +467,7 @@ export class StreamFeed<
     return this.client.get<FollowStatsAPIResponse>({
       url: 'stats/follow/',
       qs,
-      token: this.client.getOrCreateToken(),
+      token: this.client.getOrCreateToken() || this.token,
     });
   }
 


### PR DESCRIPTION
Since there is no url parameters in this endpoint, feed id extraction isn't automatic in the backend and we use `getOrCreateToken` but it won't leverage if custom token is given to feed constructor.

Fixes #436