### PR TITLE
Drop refresh endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -39,8 +39,6 @@ export type APIResponse = { duration?: string };
 
 export type FileUploadAPIResponse = APIResponse & { file: string };
 
-export type RefreshUrlAPIResponse = APIResponse & { url: string };
-
 export type OnUploadProgress = (progressEvent: ProgressEvent) => void;
 
 export type ClientOptions = {

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,4 +1,4 @@
-import { StreamClient, OnUploadProgress, RefreshUrlAPIResponse } from './client';
+import { StreamClient, OnUploadProgress } from './client';
 
 export class StreamFileStore {
   client: StreamClient;
@@ -38,20 +38,6 @@ export class StreamFileStore {
     return this.client.delete({
       url: `files/`,
       qs: { url: uri },
-      token: this.token,
-    });
-  }
-
-  /**
-   * Explicitly refresh CDN urls for uploaded files on the Stream CDN (only needed for files on the Stream CDN).
-   * Note that Stream CDN is not enabled by default, if in doubt please contact us.
-   * @param  {string} uri full uploaded file url that needs to be refreshed
-   * @return {Promise<RefreshUrlAPIResponse>}
-   */
-  refreshUrl(uri: string) {
-    return this.client.post<RefreshUrlAPIResponse>({
-      url: 'files/refresh/',
-      body: { url: uri },
       token: this.token,
     });
   }

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,4 +1,4 @@
-import { StreamClient, FileUploadAPIResponse, OnUploadProgress, RefreshUrlAPIResponse } from './client';
+import { StreamClient, FileUploadAPIResponse, OnUploadProgress } from './client';
 
 export type ImageProcessOptions = {
   crop?: string | 'top' | 'bottom' | 'left' | 'right' | 'center';
@@ -46,20 +46,6 @@ export class StreamImageStore {
     return this.client.delete({
       url: `images/`,
       qs: { url: uri },
-      token: this.token,
-    });
-  }
-
-  /**
-   * Explicitly refresh CDN urls for uploaded images on the Stream CDN (only needed for files on the Stream CDN).
-   * Note that Stream CDN is not enabled by default, if in doubt please contact us.
-   * @param  {string} uri full uploaded image url that needs to be refreshed
-   * @return {Promise<RefreshUrlAPIResponse>}
-   */
-  refreshUrl(uri: string) {
-    return this.client.post<RefreshUrlAPIResponse>({
-      url: 'images/refresh/',
-      body: { url: uri },
       token: this.token,
     });
   }

--- a/test/integration/cloud/files.js
+++ b/test/integration/cloud/files.js
@@ -54,14 +54,6 @@ describe('Files', () => {
     });
   });
 
-  describe('When refreshUrl is requested', () => {
-    ctx.requestShouldNotError(async () => {
-      ctx.response = await ctx.alice.files.refreshUrl(fileURL);
-      ctx.response.should.not.be.empty;
-      ctx.response.url.should.be.eql(fileURL);
-    });
-  });
-
   describe("When bob tries to delete alice's file", () => {
     ctx.requestShouldError(403, async () => {
       ctx.response = await ctx.bob.files.delete(fileURL);

--- a/test/integration/cloud/images.js
+++ b/test/integration/cloud/images.js
@@ -55,14 +55,6 @@ describe('Images', () => {
     });
   });
 
-  describe('When refreshUrl is requested', () => {
-    ctx.requestShouldNotError(async () => {
-      ctx.response = await ctx.alice.images.refreshUrl(imageUrl);
-      ctx.response.should.not.be.empty;
-      ctx.response.url.should.be.eql(imageUrl);
-    });
-  });
-
   describe('When the image {imageUrl} is requested', () => {
     ctx.test('should return 200', function (done) {
       request.get(imageUrl, function (err, res) {

--- a/test/unit/common/files_test.js
+++ b/test/unit/common/files_test.js
@@ -30,17 +30,6 @@ describe('[UNIT] Files (Common)', function () {
     expect(store.token).to.be('token');
   });
 
-  it('#refreshUrl', function () {
-    store.refreshUrl(uri);
-    td.verify(
-      post({
-        url: 'files/refresh/',
-        body: { url: uri },
-        token: 'token',
-      }),
-    );
-  });
-
   it('#delete', function () {
     store.delete(uri);
 

--- a/test/unit/common/images_test.js
+++ b/test/unit/common/images_test.js
@@ -33,17 +33,6 @@ describe('[UNIT] Images (Common)', function () {
     expect(store.token).to.be('token');
   });
 
-  it('#refreshUrl', function () {
-    store.refreshUrl(uri);
-    td.verify(
-      post({
-        url: 'images/refresh/',
-        body: { url: uri },
-        token: 'token',
-      }),
-    );
-  });
-
   it('#process', function () {
     const options = { crop: 'bottom', resize: 'scale', h: 100, w: 100 };
     store.process(uri, options);


### PR DESCRIPTION
* API does it automatically
* Good to drop since new CDN wasn't enabled so far (~if somebody is calling it, they just need to drop those calls~ I confirmed, no calls)