### PR TITLE
FIX: EnrichedReaction latest_children and own_children type declarations

### DIFF
--- a/src/reaction.ts
+++ b/src/reaction.ts
@@ -35,15 +35,22 @@ export type Reaction<T extends UR = UR> = {
 
 export type ReactionAPIResponse<T extends UR = UR> = APIResponse & Reaction<T>;
 
+export type ChildReactionsRecords<
+  ReactionType extends UR = UR,
+  ChildReactionType extends UR = UR,
+  UserType extends UR = UR
+  // eslint-disable-next-line no-use-before-define
+> = Record<string, EnrichedReaction<ReactionType, ChildReactionType, UserType>[]>;
+
 export type EnrichedReaction<
   ReactionType extends UR = UR,
   ChildReactionType extends UR = UR,
   UserType extends UR = UR
 > = Reaction<ReactionType | ChildReactionType> & {
   children_counts: Record<string, number>;
-  latest_children: Record<string, ChildReactionType>;
+  latest_children: ChildReactionsRecords<ReactionType, ChildReactionType, UserType>;
   latest_children_extra?: Record<string, { next?: string }>;
-  own_children?: Record<string, ChildReactionType>;
+  own_children?: ChildReactionsRecords<ReactionType, ChildReactionType, UserType>;
   user?: EnrichedUser<UserType>;
 };
 


### PR DESCRIPTION
`EnrichedReaction.latest_children` and `EnrichedReaction.own_children` are records. Their values are arrays of child reactions, not single child reactions objects. See the attached screenshot:

![image](https://user-images.githubusercontent.com/32706194/143272907-d94664c8-4201-4030-9d97-bc895f99618e.png)
