### PR TITLE
BREAKING: Refactor Generics into Single Generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ client.feed('user', 'ken').updateActivityToTargets('foreign_id:1234', timestamp,
 ### Typescript
 
 ```ts
-import { connect, EnrichedActivity, NotificationActivity } from getstream;
+import { connect, UR, EnrichedActivity, NotificationActivity } from getstream;
 
 type User1Type = { name: string; username: string; image?: string };
 type User2Type = { name: string; avatar?: string };
@@ -278,13 +278,16 @@ type Collection2Type = { branch: number; location: string };
 type ReactionType = { text: string };
 type ChildReactionType = { text?: string };
 
-const client = connect<
-  User1Type | User2Type,
-  ActivityType,
-  Collection1Type | Collection2Type,
-  ReactionType,
-  ChildReactionType
->('api_key', 'secret!', 'app_id');
+type StreamType = {
+  userType: User1Type | User2Type,
+  activityType: ActivityType,
+  collectionType: Collection1Type | Collection2Type,
+  reactionType: ReactionType,
+  childReactionType: ChildReactionType,
+  personalizationType: UR,
+}
+
+const client = connect<StreamType>('api_key', 'secret!', 'app_id');
 
 // if you have different union types like "User1Type | User2Type" you can use type guards as follow:
 // https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
@@ -301,21 +304,21 @@ client
     return id;
   });
 
-// notification: StreamFeed<User1Type | User2Type, ActivityType, Collection1Type | Collection2Type, ReactionType, ChildReactionType>
+// notification: StreamFeed<StreamType>
 const timeline = client.feed('timeline', 'feed_id');
 timeline.get({ withOwnChildren: true, withOwnReactions: true }).then((response) => {
-  // response: FeedAPIResponse<User1Type | User2Type, ActivityType, Collection1Type | Collection2Type, ReactionType, ChildReactionType>
+  // response: FeedAPIResponse<StreamType>
   if (response.next !== '') return response.next;
 
-  return (response.results as EnrichedActivity<User2Type, ActivityType>[]).map((activity) => {
+  return (response.results as EnrichedActivity<StreamType>[]).map((activity) => {
     return activity.id + activity.text + (activity.actor as User2Type).name;
   });
 });
 
-// notification: StreamFeed<User1Type | User2Type, ActivityType, Collection1Type | Collection2Type, ReactionType, ChildReactionType>
+// notification: StreamFeed<StreamType>
 const notification = client.feed('notification', 'feed_id');
 notification.get({ mark_read: true, mark_seen: true }).then((response) => {
-  // response: FeedAPIResponse<User1Type | User2Type, ActivityType, Collection1Type | Collection2Type, ReactionType, ChildReactionType>
+  // response: FeedAPIResponse<StreamType>
   if (response.unread || response.unseen) return response.next;
 
   return (response.results as NotificationActivity<ActivityType>[]).map((activityGroup) => {
@@ -324,7 +327,7 @@ notification.get({ mark_read: true, mark_seen: true }).then((response) => {
   });
 });
 
-client.collections.get('collection_1', 'taco').then((item: CollectionEntry<Collection1Type>) => {
+client.collections.get('collection_1', 'taco').then((item: CollectionEntry<StreamType>) => {
   if (item.data.rating) return { [item.data.cid]: item.data.rating };
   return item.id;
 });

--- a/src/batch_operations.ts
+++ b/src/batch_operations.ts
@@ -1,4 +1,4 @@
-import { StreamClient, APIResponse } from './client';
+import { StreamClient, APIResponse, DefaultGenerics } from './client';
 import utils from './utils';
 
 type BaseFollowRelation = {
@@ -24,7 +24,11 @@ export type UnfollowRelation = BaseFollowRelation & {
  * @param {string[]}  feeds    Array of feed id in form of `${feedSlug}:${feedId}`
  * @return {Promise<APIResponse>}
  */
-function addToMany<ActivityType>(this: StreamClient, activity: ActivityType, feeds: string[]) {
+function addToMany<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics>(
+  this: StreamClient,
+  activity: StreamFeedGenerics['activityType'],
+  feeds: string[],
+) {
   this._throwMissingApiSecret();
 
   return this.post<APIResponse>({

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -1,65 +1,62 @@
-import { StreamClient, APIResponse, UR } from './client';
+import { StreamClient, APIResponse, DefaultGenerics } from './client';
 import { SiteError } from './errors';
 
-type BaseCollection<CollectionType> = {
+type BaseCollection<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = {
   collection: string;
-  data: CollectionType;
+  data: StreamFeedGenerics['collectionType'];
   id: string;
 };
 
-export type CollectionItem<CollectionType extends UR = UR> = CollectionType & {
-  id: string;
-  user_id?: string;
-};
+export type CollectionItem<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  StreamFeedGenerics['collectionType'] & {
+    id: string;
+    user_id?: string;
+  };
 
-export type CollectionResponse<CollectionType extends UR = UR> = BaseCollection<CollectionType> & {
-  created_at: string;
-  foreign_id: string;
-  updated_at: string;
-};
+export type CollectionResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  BaseCollection<StreamFeedGenerics> & {
+    created_at: string;
+    foreign_id: string;
+    updated_at: string;
+  };
 
-export type NewCollectionEntry<CollectionType extends UR = UR> = BaseCollection<CollectionType> & {
-  user_id?: string;
-};
+export type NewCollectionEntry<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  BaseCollection<StreamFeedGenerics> & {
+    user_id?: string;
+  };
 
-export type CollectionAPIResponse<CollectionType extends UR = UR> = APIResponse & CollectionResponse<CollectionType>;
+export type CollectionAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse &
+  CollectionResponse<StreamFeedGenerics>;
 
-export type SelectCollectionAPIResponse<CollectionType extends UR = UR> = APIResponse & {
+export type SelectCollectionAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse & {
   response: {
-    data: CollectionResponse<CollectionType>[];
+    data: CollectionResponse<StreamFeedGenerics>[];
   };
 };
 
-export type UpsertCollectionAPIResponse<CollectionType extends UR = UR> = APIResponse & {
+export type UpsertCollectionAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse & {
   data: {
-    [key: string]: CollectionItem<CollectionType>[];
+    [key: string]: CollectionItem<StreamFeedGenerics>[];
   };
 };
 
-export type UpsertManyCollectionRequest<CollectionType extends UR = UR> = {
-  [collection: string]: CollectionItem<CollectionType>[];
+export type UpsertManyCollectionRequest<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = {
+  [collection: string]: CollectionItem<StreamFeedGenerics>[];
 };
 
-export class CollectionEntry<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
-> {
+export class CollectionEntry<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> {
   id: string;
   collection: string;
-  store: Collections<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>; // eslint-disable-line no-use-before-define
-  data: CollectionType | null;
+  store: Collections<StreamFeedGenerics>; // eslint-disable-line no-use-before-define
+  data: StreamFeedGenerics['collectionType'] | null;
   full?: unknown;
 
   constructor(
     // eslint-disable-next-line no-use-before-define
-    store: Collections<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>,
+    store: Collections<StreamFeedGenerics>,
     collection: string,
     id: string,
-    data: CollectionType,
+    data: StreamFeedGenerics['collectionType'],
   ) {
     this.collection = collection;
     this.store = store;
@@ -75,7 +72,7 @@ export class CollectionEntry<
    * get item from collection and sync data
    * @method get
    * @memberof CollectionEntry.prototype
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example collection.get("0c7db91c-67f9-11e8-bcd9-fe00a9219401")
    */
   async get() {
@@ -90,11 +87,11 @@ export class CollectionEntry<
    * @link https://getstream.io/activity-feeds/docs/node/collections_introduction/?language=js#adding-collections
    * @method add
    * @memberof CollectionEntry.prototype
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example collection.add("cheese101", {"name": "cheese burger","toppings": "cheese"})
    */
   async add() {
-    const response = await this.store.add(this.collection, this.id, this.data as CollectionType);
+    const response = await this.store.add(this.collection, this.id, this.data as StreamFeedGenerics['collectionType']);
     this.data = response.data;
     this.full = response;
     return response;
@@ -105,12 +102,16 @@ export class CollectionEntry<
    * @link https://getstream.io/activity-feeds/docs/node/collections_introduction/?language=js#updating-collections
    * @method update
    * @memberof CollectionEntry.prototype
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example store.update("0c7db91c-67f9-11e8-bcd9-fe00a9219401", {"name": "cheese burger","toppings": "cheese"})
    * @example store.update("cheese101", {"name": "cheese burger","toppings": "cheese"})
    */
   async update() {
-    const response = await this.store.update(this.collection, this.id, this.data as CollectionType);
+    const response = await this.store.update(
+      this.collection,
+      this.id,
+      this.data as StreamFeedGenerics['collectionType'],
+    );
     this.data = response.data;
     this.full = response;
     return response;
@@ -132,15 +133,8 @@ export class CollectionEntry<
   }
 }
 
-export class Collections<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
-> {
-  client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>;
+export class Collections<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> {
+  client: StreamClient<StreamFeedGenerics>;
   token: string;
 
   /**
@@ -150,10 +144,7 @@ export class Collections<
    * @param {StreamCloudClient} client Stream client this collection is constructed from
    * @param {string} token JWT token
    */
-  constructor(
-    client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>,
-    token: string,
-  ) {
+  constructor(client: StreamClient<StreamFeedGenerics>, token: string) {
     this.client = client;
     this.token = token;
   }
@@ -163,15 +154,8 @@ export class Collections<
     return itemId === undefined ? url : `${url}${itemId}/`;
   };
 
-  entry(collection: string, itemId: string, itemData: CollectionType) {
-    return new CollectionEntry<
-      UserType,
-      ActivityType,
-      CollectionType,
-      ReactionType,
-      ChildReactionType,
-      PersonalizationType
-    >(this, collection, itemId, itemData);
+  entry(collection: string, itemId: string, itemData: StreamFeedGenerics['collectionType']) {
+    return new CollectionEntry<StreamFeedGenerics>(this, collection, itemId, itemData);
   }
 
   /**
@@ -181,11 +165,11 @@ export class Collections<
    * @memberof Collections.prototype
    * @param  {string}   collection  collection name
    * @param  {string}   itemId  id for this entry
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example collection.get("food", "0c7db91c-67f9-11e8-bcd9-fe00a9219401")
    */
   async get(collection: string, itemId: string) {
-    const response = await this.client.get<CollectionAPIResponse<CollectionType>>({
+    const response = await this.client.get<CollectionAPIResponse<StreamFeedGenerics>>({
       url: this.buildURL(collection, itemId),
       token: this.token,
     });
@@ -203,11 +187,11 @@ export class Collections<
    * @param  {string}   collection  collection name
    * @param  {string | null}    itemId  entry id, if null a random id will be assigned to the item
    * @param  {CollectionType}   itemData  ObjectStore data
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example collection.add("food", "cheese101", {"name": "cheese burger","toppings": "cheese"})
    */
-  async add(collection: string, itemId: string | null, itemData: CollectionType) {
-    const response = await this.client.post<CollectionAPIResponse<CollectionType>>({
+  async add(collection: string, itemId: string | null, itemData: StreamFeedGenerics['collectionType']) {
+    const response = await this.client.post<CollectionAPIResponse<StreamFeedGenerics>>({
       url: this.buildURL(collection),
       body: {
         id: itemId === null ? undefined : itemId,
@@ -229,12 +213,12 @@ export class Collections<
    * @param  {string}   collection  collection name
    * @param  {string}   entryId  Collection object id
    * @param  {CollectionType}   data  ObjectStore data
-   * @return {Promise<CollectionEntry<CollectionType>>}
+   * @return {Promise<CollectionEntry<StreamFeedGenerics>>}
    * @example store.update("0c7db91c-67f9-11e8-bcd9-fe00a9219401", {"name": "cheese burger","toppings": "cheese"})
    * @example store.update("food", "cheese101", {"name": "cheese burger","toppings": "cheese"})
    */
-  async update(collection: string, entryId: string, data: CollectionType) {
-    const response = await this.client.put<CollectionAPIResponse<CollectionType>>({
+  async update(collection: string, entryId: string, data: StreamFeedGenerics['collectionType']) {
+    const response = await this.client.put<CollectionAPIResponse<StreamFeedGenerics>>({
       url: this.buildURL(collection, entryId),
       body: { data },
       token: this.token,
@@ -268,17 +252,17 @@ export class Collections<
    * @method upsert
    * @memberof Collections.prototype
    * @param  {string}   collection  collection name
-   * @param {NewCollectionEntry<CollectionType> | NewCollectionEntry<CollectionType>[]} data - A single json object or an array of objects
-   * @return {Promise<UpsertCollectionAPIResponse<CollectionType>>}
+   * @param {NewCollectionEntry<StreamFeedGenerics> | NewCollectionEntry<StreamFeedGenerics>[]} data - A single json object or an array of objects
+   * @return {Promise<UpsertCollectionAPIResponse<StreamFeedGenerics>>}
    */
-  upsert(collection: string, data: CollectionItem<CollectionType> | CollectionItem<CollectionType>[]) {
+  upsert(collection: string, data: CollectionItem<StreamFeedGenerics> | CollectionItem<StreamFeedGenerics>[]) {
     if (!this.client.usingApiSecret) {
       throw new SiteError('This method can only be used server-side using your API Secret');
     }
 
     if (!Array.isArray(data)) data = [data];
 
-    return this.client.post<UpsertCollectionAPIResponse<CollectionType>>({
+    return this.client.post<UpsertCollectionAPIResponse<StreamFeedGenerics>>({
       url: 'collections/',
       serviceName: 'api',
       body: { data: { [collection]: data } },
@@ -293,14 +277,14 @@ export class Collections<
    * @memberof Collections.prototype
    * @param  {string}   collection  collection name
    * @param {UpsertManyCollectionRequest} items - A single json object that contains information of many collections
-   * @return {Promise<UpsertCollectionAPIResponse<CollectionType>>}
+   * @return {Promise<UpsertCollectionAPIResponse<StreamFeedGenerics>>}
    */
   upsertMany(items: UpsertManyCollectionRequest) {
     if (!this.client.usingApiSecret) {
       throw new SiteError('This method can only be used server-side using your API Secret');
     }
 
-    return this.client.post<UpsertCollectionAPIResponse<CollectionType>>({
+    return this.client.post<UpsertCollectionAPIResponse<StreamFeedGenerics>>({
       url: 'collections/',
       serviceName: 'api',
       body: { data: items },
@@ -315,7 +299,7 @@ export class Collections<
    * @memberof Collections.prototype
    * @param {string} collection  collection name
    * @param {string | string[]} ids - A single object id or an array of ids
-   * @return {Promise<SelectCollectionAPIResponse<CollectionType>>}
+   * @return {Promise<SelectCollectionAPIResponse<StreamFeedGenerics>>}
    */
   select(collection: string, ids: string | string[]) {
     if (!this.client.usingApiSecret) {
@@ -324,7 +308,7 @@ export class Collections<
 
     if (!Array.isArray(ids)) ids = [ids];
 
-    return this.client.get<SelectCollectionAPIResponse<CollectionType>>({
+    return this.client.get<SelectCollectionAPIResponse<StreamFeedGenerics>>({
       url: 'collections/',
       serviceName: 'api',
       qs: { foreign_ids: ids.map((id) => `${collection}:${id}`).join(',') },

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,4 +1,4 @@
-import { StreamClient, UR, ClientOptions } from './client';
+import { StreamClient, ClientOptions, DefaultGenerics } from './client';
 
 /**
  * Create StreamClient
@@ -23,14 +23,12 @@ import { StreamClient, UR, ClientOptions } from './client';
  * @example <caption>where streamURL looks like</caption>
  * "https://thierry:pass@gestream.io/?app=1"
  */
-export function connect<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
->(apiKey: string, apiSecret: string | null, appId?: string, options?: ClientOptions) {
+export function connect<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics>(
+  apiKey: string,
+  apiSecret: string | null,
+  appId?: string,
+  options?: ClientOptions,
+) {
   if (typeof process !== 'undefined' && process.env?.STREAM_URL && !apiKey) {
     const parts = /https:\/\/(\w+):(\w+)@([\w-]*).*\?app_id=(\d+)/.exec(process.env.STREAM_URL) || [];
     apiKey = parts[1];
@@ -46,10 +44,5 @@ export function connect<
     }
   }
 
-  return new StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>(
-    apiKey,
-    apiSecret,
-    appId,
-    options,
-  );
+  return new StreamClient<StreamFeedGenerics>(apiKey, apiSecret, appId, options);
 }

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -1,7 +1,7 @@
 /// <reference path="../types/modules.d.ts" />
 
 import * as Faye from 'faye';
-import { StreamClient, APIResponse, UR, RealTimeMessage } from './client';
+import { StreamClient, APIResponse, UR, RealTimeMessage, DefaultGenerics } from './client';
 import { StreamUser, EnrichedUser } from './user';
 import { FeedError, SiteError } from './errors';
 import utils from './utils';
@@ -76,78 +76,70 @@ type BaseActivity = {
   to?: string[];
 };
 
-export type NewActivity<ActivityType extends UR = UR> = ActivityType &
-  BaseActivity & {
-    actor: string | StreamUser;
-    object: string | unknown;
-    foreign_id?: string;
-    time?: string;
-  };
+export type NewActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  StreamFeedGenerics['activityType'] &
+    BaseActivity & {
+      actor: string | StreamUser;
+      object: string | unknown;
+      foreign_id?: string;
+      time?: string;
+    };
 
-export type UpdateActivity<ActivityType extends UR = UR> = ActivityType &
-  BaseActivity & {
-    actor: string;
-    foreign_id: string;
-    object: string | unknown;
-    time: string;
-  };
+export type UpdateActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  StreamFeedGenerics['activityType'] &
+    BaseActivity & {
+      actor: string;
+      foreign_id: string;
+      object: string | unknown;
+      time: string;
+    };
 
-export type Activity<ActivityType extends UR = UR> = ActivityType &
-  BaseActivity & {
-    actor: string;
-    foreign_id: string;
-    id: string;
-    object: string | unknown;
-    time: string;
-    analytics?: Record<string, number>; // ranked feeds only
-    extra_context?: UR;
-    origin?: string;
-    score?: number; // ranked feeds only
-    // ** Add new fields to EnrichedActivity as well **
-  };
+export type Activity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  StreamFeedGenerics['activityType'] &
+    BaseActivity & {
+      actor: string;
+      foreign_id: string;
+      id: string;
+      object: string | unknown;
+      time: string;
+      analytics?: Record<string, number>; // ranked feeds only
+      extra_context?: UR;
+      origin?: string;
+      score?: number; // ranked feeds only
+      // ** Add new fields to EnrichedActivity as well **
+    };
 
-export type ReactionsRecords<
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  UserType extends UR = UR,
-> = Record<string, EnrichedReaction<ReactionType, ChildReactionType, UserType>[]>;
+export type ReactionsRecords<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = Record<
+  string,
+  EnrichedReaction<StreamFeedGenerics>[]
+>;
 
-export type EnrichedActivity<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = ActivityType &
-  BaseActivity &
-  Pick<Activity, 'foreign_id' | 'id' | 'time' | 'analytics' | 'extra_context' | 'origin' | 'score'> & {
-    actor: EnrichedUser<UserType> | string;
-    // Object should be casted based on the verb
-    object:
-      | string
-      | unknown
-      | EnrichedActivity<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>
-      | EnrichedReaction<ReactionType, ChildReactionType, UserType>
-      | CollectionResponse<CollectionType>;
-    latest_reactions?: ReactionsRecords<ReactionType, ChildReactionType, UserType>;
-    latest_reactions_extra?: Record<string, { next?: string }>;
-    own_reactions?: ReactionsRecords<ReactionType, ChildReactionType, UserType>;
-    own_reactions_extra?: Record<string, { next?: string }>;
-    // Reaction posted to feed
-    reaction?: EnrichedReaction<ReactionType, ChildReactionType, UserType>;
-    // enriched reactions
-    reaction_counts?: Record<string, number>;
-  };
+export type EnrichedActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  StreamFeedGenerics['activityType'] &
+    BaseActivity &
+    Pick<Activity, 'foreign_id' | 'id' | 'time' | 'analytics' | 'extra_context' | 'origin' | 'score'> & {
+      actor: EnrichedUser<StreamFeedGenerics> | string;
+      // Object should be casted based on the verb
+      object:
+        | string
+        | unknown
+        | EnrichedActivity<StreamFeedGenerics>
+        | EnrichedReaction<StreamFeedGenerics>
+        | CollectionResponse<StreamFeedGenerics>;
+      latest_reactions?: ReactionsRecords<StreamFeedGenerics>;
+      latest_reactions_extra?: Record<string, { next?: string }>;
+      own_reactions?: ReactionsRecords<StreamFeedGenerics>;
+      own_reactions_extra?: Record<string, { next?: string }>;
+      // Reaction posted to feed
+      reaction?: EnrichedReaction<StreamFeedGenerics>;
+      // enriched reactions
+      reaction_counts?: Record<string, number>;
+    };
 
-export type FlatActivity<ActivityType extends UR = UR> = Activity<ActivityType>;
+export type FlatActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = Activity<StreamFeedGenerics>;
 
-export type FlatActivityEnriched<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = EnrichedActivity<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>;
+export type FlatActivityEnriched<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  EnrichedActivity<StreamFeedGenerics>;
 
 type BaseAggregatedActivity = {
   activity_count: number;
@@ -160,79 +152,50 @@ type BaseAggregatedActivity = {
   score?: number;
 };
 
-export type AggregatedActivity<ActivityType extends UR = UR> = BaseAggregatedActivity & {
-  activities: Activity<ActivityType>[];
-};
+export type AggregatedActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  BaseAggregatedActivity & {
+    activities: Activity<StreamFeedGenerics>[];
+  };
 
-export type AggregatedActivityEnriched<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = BaseAggregatedActivity & {
-  activities: EnrichedActivity<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[];
-};
+export type AggregatedActivityEnriched<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  BaseAggregatedActivity & {
+    activities: EnrichedActivity<StreamFeedGenerics>[];
+  };
 
 type BaseNotificationActivity = { is_read: boolean; is_seen: boolean };
 
-export type NotificationActivity<ActivityType extends UR = UR> = AggregatedActivity<ActivityType> &
-  BaseNotificationActivity;
+export type NotificationActivity<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  AggregatedActivity<StreamFeedGenerics> & BaseNotificationActivity;
 
-export type NotificationActivityEnriched<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = BaseNotificationActivity &
-  AggregatedActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>;
+export type NotificationActivityEnriched<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  BaseNotificationActivity & AggregatedActivityEnriched<StreamFeedGenerics>;
 
-export type FeedAPIResponse<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = APIResponse & {
+export type FeedAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse & {
   next: string;
   results:
-    | FlatActivity<ActivityType>[]
-    | FlatActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[]
-    | AggregatedActivity<ActivityType>[]
-    | AggregatedActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[]
-    | NotificationActivity<ActivityType>[]
-    | NotificationActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[];
+    | FlatActivity<StreamFeedGenerics>[]
+    | FlatActivityEnriched<StreamFeedGenerics>[]
+    | AggregatedActivity<StreamFeedGenerics>[]
+    | AggregatedActivityEnriched<StreamFeedGenerics>[]
+    | NotificationActivity<StreamFeedGenerics>[]
+    | NotificationActivityEnriched<StreamFeedGenerics>[];
 
   // Notification Feed only
   unread?: number;
   unseen?: number;
 };
 
-export type PersonalizationFeedAPIResponse<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = APIResponse & {
-  limit: number;
-  next: string;
-  offset: number;
-  results: FlatActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[];
-  version: string;
-};
+export type PersonalizationFeedAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> =
+  APIResponse & {
+    limit: number;
+    next: string;
+    offset: number;
+    results: FlatActivityEnriched<StreamFeedGenerics>[];
+    version: string;
+  };
 
-export type GetActivitiesAPIResponse<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-> = APIResponse & {
-  results:
-    | FlatActivity<ActivityType>[]
-    | FlatActivityEnriched<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>[];
+export type GetActivitiesAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse & {
+  results: FlatActivity<StreamFeedGenerics>[] | FlatActivityEnriched<StreamFeedGenerics>[];
 };
 
 /**
@@ -240,15 +203,8 @@ export type GetActivitiesAPIResponse<
  * The feed object contains convenience functions such add activity, remove activity etc
  * @class StreamFeed
  */
-export class StreamFeed<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
-> {
-  client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>;
+export class StreamFeed<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> {
+  client: StreamClient<StreamFeedGenerics>;
   token: string;
   id: string;
   slug: string;
@@ -267,12 +223,7 @@ export class StreamFeed<
    * @param {string} userId - The user id
    * @param {string} [token] - The authentication token
    */
-  constructor(
-    client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>,
-    feedSlug: string,
-    userId: string,
-    token: string,
-  ) {
+  constructor(client: StreamClient<StreamFeedGenerics>, feedSlug: string, userId: string, token: string) {
     if (!feedSlug || !userId) {
       throw new FeedError('Please provide a feed slug and user id, ie client.feed("user", "1")');
     }
@@ -307,16 +258,16 @@ export class StreamFeed<
    * @link https://getstream.io/activity-feeds/docs/node/adding_activities/?language=js#adding-activities-basic
    * @method addActivity
    * @memberof StreamFeed.prototype
-   * @param {NewActivity<ActivityType>} activity - The activity to add
-   * @return {Promise<Activity<ActivityType>>}
+   * @param {NewActivity<StreamFeedGenerics>} activity - The activity to add
+   * @return {Promise<Activity<StreamFeedGenerics>>}
    */
-  addActivity(activity: NewActivity<ActivityType>) {
+  addActivity(activity: NewActivity<StreamFeedGenerics>) {
     activity = utils.replaceStreamObjects(activity);
     if (!activity.actor && this.client.currentUser) {
       activity.actor = this.client.currentUser.ref();
     }
 
-    return this.client.post<Activity<ActivityType>>({
+    return this.client.post<Activity<StreamFeedGenerics>>({
       url: `feed/${this.feedUrl}/`,
       body: activity,
       token: this.token,
@@ -350,11 +301,11 @@ export class StreamFeed<
    * @link https://getstream.io/activity-feeds/docs/node/add_many_activities/?language=js#batch-add-activities
    * @method addActivities
    * @memberof StreamFeed.prototype
-   * @param  {NewActivity<ActivityType>[]}   activities Array of activities to add
-   * @return {Promise<Activity<ActivityType>[]>}
+   * @param  {NewActivity<StreamFeedGenerics>[]}   activities Array of activities to add
+   * @return {Promise<Activity<StreamFeedGenerics>[]>}
    */
-  addActivities(activities: NewActivity<ActivityType>[]) {
-    return this.client.post<Activity<ActivityType>[]>({
+  addActivities(activities: NewActivity<StreamFeedGenerics>[]) {
+    return this.client.post<Activity<StreamFeedGenerics>[]>({
       url: `feed/${this.feedUrl}/`,
       body: { activities: utils.replaceStreamObjects(activities) },
       token: this.token,
@@ -518,7 +469,7 @@ export class StreamFeed<
 
     const path = this.client.shouldUseEnrichEndpoint(options) ? 'enrich/feed/' : 'feed/';
 
-    return this.client.get<FeedAPIResponse<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>>({
+    return this.client.get<FeedAPIResponse<StreamFeedGenerics>>({
       url: `${path}${this.feedUrl}/`,
       qs: { ...options, ...extraOptions },
       token: this.token,
@@ -563,14 +514,14 @@ export class StreamFeed<
    * @link https://getstream.io/activity-feeds/docs/node/web_and_mobile/?language=js#subscribe-to-realtime-updates-via-api-client
    * @method subscribe
    * @memberof StreamFeed.prototype
-   * @param  {function} Faye.Callback<RealTimeMessage<UserType, ActivityType, CollectionType, ReactionType>> Callback to call on completion
+   * @param  {function} Faye.Callback<RealTimeMessage<StreamFeedGenerics>> Callback to call on completion
    * @return {Promise<Faye.Subscription>}
    * @example
    * feed.subscribe(callback).then(function(){
    * 		console.log('we are now listening to changes');
    * });
    */
-  subscribe(callback: Faye.SubscribeCallback<RealTimeMessage<UserType, ActivityType, CollectionType, ReactionType>>) {
+  subscribe(callback: Faye.SubscribeCallback<RealTimeMessage<StreamFeedGenerics>>) {
     if (!this.client.appId) {
       throw new SiteError(
         'Missing app id, which is needed to subscribe, use var client = stream.connect(key, secret, appId);',
@@ -651,7 +602,7 @@ export class StreamFeed<
     if (addedTargets) body.added_targets = addedTargets;
     if (removedTargets) body.removed_targets = removedTargets;
 
-    return this.client.post<APIResponse & Activity<ActivityType> & { added?: string[]; removed?: string[] }>({
+    return this.client.post<APIResponse & Activity<StreamFeedGenerics> & { added?: string[]; removed?: string[] }>({
       url: `feed_targets/${this.feedUrl}/activity_to_targets/`,
       token: this.token,
       body,

--- a/src/personalization.ts
+++ b/src/personalization.ts
@@ -1,4 +1,4 @@
-import { StreamClient, APIResponse, UR } from './client';
+import { StreamClient, APIResponse, UR, DefaultGenerics } from './client';
 
 /**
  * Manage api calls for personalization
@@ -6,24 +6,17 @@ import { StreamClient, APIResponse, UR } from './client';
  * @class Personalization
  */
 
-export type PersonalizationAPIResponse<PersonalizationType extends UR = UR> = APIResponse & {
+export type PersonalizationAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse & {
   app_id: string;
   next: string;
-  results: PersonalizationType[];
+  results: Array<StreamFeedGenerics['personalizationType']>;
   limit?: number;
   offset?: number;
   version?: string;
 };
 
-export class Personalization<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
-> {
-  client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>;
+export class Personalization<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> {
+  client: StreamClient<StreamFeedGenerics>;
 
   /**
    * Initialize the Personalization class
@@ -32,9 +25,7 @@ export class Personalization<
    * @memberof Personalization.prototype
    * @param {StreamClient} client - The stream client
    */
-  constructor(
-    client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>,
-  ) {
+  constructor(client: StreamClient<StreamFeedGenerics>) {
     this.client = client;
   }
 
@@ -45,11 +36,11 @@ export class Personalization<
    * @memberof Personalization.prototype
    * @param {string} resource - personalized resource endpoint i.e "follow_recommendations"
    * @param {object} options  Additional options
-   * @return {Promise<PersonalizationAPIResponse<PersonalizationType>>} Promise object. Personalized feed
+   * @return {Promise<PersonalizationAPIResponse<StreamFeedGenerics>>} Promise object. Personalized feed
    * @example client.personalization.get('follow_recommendations', {foo: 'bar', baz: 'qux'})
    */
   get(resource: string, options: Record<string, string> & { token?: string } = {}) {
-    return this.client.get<PersonalizationAPIResponse<PersonalizationType>>({
+    return this.client.get<PersonalizationAPIResponse<StreamFeedGenerics>>({
       url: `${resource}/`,
       serviceName: 'personalization',
       qs: options,
@@ -65,11 +56,11 @@ export class Personalization<
    * @param {string} resource - personalized resource endpoint i.e "follow_recommendations"
    * @param {object} options - Additional options
    * @param {object} data - Data to send in the payload
-   * @return {Promise<PersonalizationAPIResponse<PersonalizationType>>} Promise object. Data that was posted if successful, or an error.
+   * @return {Promise<PersonalizationAPIResponse<StreamFeedGenerics>>} Promise object. Data that was posted if successful, or an error.
    * @example client.personalization.post('follow_recommendations', {foo: 'bar', baz: 'qux'})
    */
   post(resource: string, options: Record<string, string> = {}, data: UR = {}) {
-    return this.client.post<PersonalizationAPIResponse<PersonalizationType>>({
+    return this.client.post<PersonalizationAPIResponse<StreamFeedGenerics>>({
       url: `${resource}/`,
       serviceName: 'personalization',
       qs: options,
@@ -85,11 +76,11 @@ export class Personalization<
    * @memberof Personalization.prototype
    * @param {object} resource - personalized resource endpoint i.e "follow_recommendations"
    * @param {object} options - Additional options
-   * @return {Promise<PersonalizationAPIResponse<PersonalizationType>>} Promise object. Data that was deleted if successful, or an error.
+   * @return {Promise<PersonalizationAPIResponse<StreamFeedGenerics>>} Promise object. Data that was deleted if successful, or an error.
    * @example client.personalization.delete('follow_recommendations', {foo: 'bar', baz: 'qux'})
    */
   delete(resource: string, options: Record<string, string> = {}) {
-    return this.client.delete<PersonalizationAPIResponse<PersonalizationType>>({
+    return this.client.delete<PersonalizationAPIResponse<StreamFeedGenerics>>({
       url: `${resource}/`,
       serviceName: 'personalization',
       qs: options,

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,32 +1,25 @@
-import { StreamClient, APIResponse, UR } from './client';
+import { StreamClient, APIResponse, DefaultGenerics } from './client';
 
-export type EnrichedUser<UserType extends UR = UR> = {
+export type EnrichedUser<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = {
   created_at: string;
-  data: UserType;
+  data: StreamFeedGenerics['userType'];
   id: string;
   updated_at: string;
 };
 
-export type UserAPIResponse<UserType extends UR = UR> = APIResponse &
-  EnrichedUser<UserType> & {
+export type UserAPIResponse<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> = APIResponse &
+  EnrichedUser<StreamFeedGenerics> & {
     // present only in profile response
     followers_count?: number;
     following_count?: number;
   };
 
-export class StreamUser<
-  UserType extends UR = UR,
-  ActivityType extends UR = UR,
-  CollectionType extends UR = UR,
-  ReactionType extends UR = UR,
-  ChildReactionType extends UR = UR,
-  PersonalizationType extends UR = UR,
-> {
-  client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>;
+export class StreamUser<StreamFeedGenerics extends DefaultGenerics = DefaultGenerics> {
+  client: StreamClient<StreamFeedGenerics>;
   token: string;
   id: string;
-  data?: UserType;
-  full?: UserAPIResponse<UserType>;
+  data?: StreamFeedGenerics['userType'];
+  full?: UserAPIResponse<StreamFeedGenerics>;
   private url: string;
 
   /**
@@ -39,11 +32,7 @@ export class StreamUser<
    * @param {string} userAuthToken JWT token
    * @example new StreamUser(client, "123", "eyJhbGciOiJIUzI1...")
    */
-  constructor(
-    client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>,
-    userId: string,
-    userAuthToken: string,
-  ) {
+  constructor(client: StreamClient<StreamFeedGenerics>, userId: string, userAuthToken: string) {
     this.client = client;
     this.id = userId;
     this.data = undefined;
@@ -79,7 +68,7 @@ export class StreamUser<
    * @return {Promise<StreamUser>}
    */
   async get(options?: { with_follow_counts?: boolean }) {
-    const response = await this.client.get<UserAPIResponse<UserType>>({
+    const response = await this.client.get<UserAPIResponse<StreamFeedGenerics>>({
       url: this.url,
       token: this.token,
       qs: options,
@@ -98,8 +87,8 @@ export class StreamUser<
    * @param {boolean} [options.get_or_create] if user already exists return it
    * @return {Promise<StreamUser>}
    */
-  async create(data?: UserType, options?: { get_or_create?: boolean }) {
-    const response = await this.client.post<UserAPIResponse<UserType>>({
+  async create(data?: StreamFeedGenerics['userType'], options?: { get_or_create?: boolean }) {
+    const response = await this.client.post<UserAPIResponse<StreamFeedGenerics>>({
       url: 'user/',
       body: {
         id: this.id,
@@ -121,8 +110,8 @@ export class StreamUser<
    * @param {object} data user date stored in stream
    * @return {Promise<StreamUser>}
    */
-  async update(data?: Partial<UserType>) {
-    const response = await this.client.put<UserAPIResponse<UserType>>({
+  async update(data?: Partial<StreamFeedGenerics['userType']>) {
+    const response = await this.client.put<UserAPIResponse<StreamFeedGenerics>>({
       url: this.url,
       body: {
         data: data || this.data || {},
@@ -142,7 +131,7 @@ export class StreamUser<
    * @param {object} data user date stored in stream
    * @return {Promise<StreamUser>}
    */
-  getOrCreate(data: UserType) {
+  getOrCreate(data: StreamFeedGenerics['userType']) {
     return this.create(data, { get_or_create: true });
   }
 

--- a/test/typescript/test.ts
+++ b/test/typescript/test.ts
@@ -16,6 +16,7 @@ import {
   StreamFeed,
   FeedAPIResponse,
   FlatActivity,
+  RealTimeMessage,
 } from '../..';
 
 type UserType = { name: string; image?: string };
@@ -25,23 +26,22 @@ type ReactionType = { rText: string };
 type ChildReactionType = { cText: string };
 type T = {};
 
+type Generics = {
+  userType: UserType;
+  activityType: ActivityType;
+  collectionType: CollectionType;
+  reactionType: ReactionType;
+  childReactionType: ChildReactionType;
+  personalizationType: Faye.UR;
+};
+
 let voidReturn: void;
 let voidPromise: Promise<void>;
 let emptyAPIPromise: Promise<APIResponse>;
 
-let client: StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType> = connect<
-  UserType,
-  ActivityType,
-  CollectionType,
-  ReactionType,
-  ChildReactionType
->('api_key', 'secret!', 'app_id');
+let client: StreamClient<Generics> = connect<Generics>('api_key', 'secret!', 'app_id');
 
-client = new StreamClient<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>(
-  'api_key',
-  'secret!',
-  'app_id',
-);
+client = new StreamClient<Generics>('api_key', 'secret!', 'app_id');
 
 connect('', null);
 connect('', null, '', {});
@@ -105,7 +105,7 @@ client.shouldUseEnrichEndpoint({
 // @ts-expect-error
 client.shouldUseEnrichEndpoint({ enrich: '' });
 
-const faye: Faye.Client = client.getFayeClient();
+const faye: Faye.Client<RealTimeMessage<Generics>> = client.getFayeClient();
 client.getFayeClient(100);
 
 const upload: Promise<FileUploadAPIResponse> = client.upload('/file', 'uri');
@@ -158,7 +158,7 @@ client.updateActivity(emptyActivity);
 // @ts-expect-error
 client.updateActivities([emptyActivity]);
 
-const partialUpdatePromise: Promise<Activity<ActivityType>> = client.activityPartialUpdate({
+const partialUpdatePromise: Promise<Activity<Generics>> = client.activityPartialUpdate({
   id: '',
   set: { aText: '' },
   unset: ['attachments'],
@@ -170,7 +170,7 @@ client.activityPartialUpdate({ unset: ['missing'] });
 // @ts-expect-error
 client.activityPartialUpdate({ set: { missing: '' } });
 
-const partialUpdatesPromise: Promise<{ activities: Activity<ActivityType>[] }> = client.activitiesPartialUpdate([
+const partialUpdatesPromise: Promise<{ activities: Activity<Generics>[] }> = client.activitiesPartialUpdate([
   {
     id: '',
     set: { aText: '' },
@@ -184,9 +184,7 @@ client.activityPartialUpdate([{ unset: ['missing'] }]);
 // @ts-expect-error
 client.activityPartialUpdate([{ set: { missing: '' } }]);
 
-const activitiesPromise: Promise<
-  GetActivitiesAPIResponse<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>
-> = client.getActivities({ ids: ['', ''] });
+const activitiesPromise: Promise<GetActivitiesAPIResponse<Generics>> = client.getActivities({ ids: ['', ''] });
 activitiesPromise.then(({ results }) => {
   results[0].id as string;
   results[0].time as string;
@@ -202,9 +200,7 @@ client.getActivities({});
 // @ts-expect-error
 client.getActivities();
 
-const pFeedPromise: Promise<
-  PersonalizationFeedAPIResponse<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>
-> = client.personalizedFeed({ enrich: true });
+const pFeedPromise: Promise<PersonalizationFeedAPIResponse<Generics>> = client.personalizedFeed({ enrich: true });
 pFeedPromise.then((pFeed) => {
   pFeed.results as Array<EnrichedActivity>;
   pFeed.version as string;
@@ -213,31 +209,26 @@ pFeedPromise.then((pFeed) => {
   pFeed.offset as number;
 });
 
-const userPromise: Promise<StreamUser<UserType>> = client.setUser({ name: '' });
+const userPromise: Promise<StreamUser<Generics>> = client.setUser({ name: '' });
 // @ts-expect-error
 client.setUser({ username: '' });
 
-const user: StreamUser<UserType> = client.user('user_id');
-const userGet: Promise<StreamUser<UserType>> = client.user('user_id').get();
+const user: StreamUser<Generics> = client.user('user_id');
+const userGet: Promise<StreamUser<Generics>> = client.user('user_id').get();
 client.user('user_id').get({ with_follow_counts: true });
 // @ts-expect-error
 client.user('user_id').get({ with_follow_counts: 1 });
 // @ts-expect-error
 client.user('user_id').get({ list: true });
 
-const timeline: StreamFeed<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType> = client.feed(
-  'timeline',
-  'feed_id',
-);
+const timeline: StreamFeed<Generics> = client.feed('timeline', 'feed_id');
 
-timeline
-  .get({ withOwnChildren: true, withOwnReactions: true })
-  .then((response: FeedAPIResponse<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType>) => {
-    response.next as string;
-    response.unread as number;
-    response.unseen as number;
-    response.results as FlatActivity<ActivityType>[];
-  });
+timeline.get({ withOwnChildren: true, withOwnReactions: true }).then((response: FeedAPIResponse<Generics>) => {
+  response.next as string;
+  response.unread as number;
+  response.unseen as number;
+  response.results as FlatActivity<Generics>[];
+});
 
 client
   .feed('notification', 'feed_id')
@@ -246,10 +237,10 @@ client
     response.next as string;
     response.unread as number;
     response.unseen as number;
-    response.results as NotificationActivity<ActivityType>[];
+    response.results as NotificationActivity<Generics>[];
   });
 
-const collection: Promise<CollectionEntry<CollectionType>> = client.collections.get('collection_1', 'taco');
+const collection: Promise<CollectionEntry<Generics>> = client.collections.get('collection_1', 'taco');
 
 collection.then((item) => {
   item.id as string;


### PR DESCRIPTION
Currently internal generics are verbose and hard to maintain, with this change we move to a single generic type passed into StreamFeed by users which gets passed around easily in internal functions. We also no longer need to maintain the generics order. This PR includes no JS changes.

## Changelog
- Breaking change for apps using Typescript and Stream Generics, in order to upgrade:

```typescript
- connect<UserType, ActivityType, CollectionType, ReactionType, ChildReactionType, PersonalizationType>()

+ connect<{
  userType: UserType,
  activityType: ActivityType,
  collectionType: CollectionType
  reactionType: ReactionType,
  childReactionType: ChildReactionType,
  personalizationType: PersonalizationType,
}>()
```
