### PR TITLE
chore: removed deprecated @types/jwt-decode package

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
   "dependencies": {
     "@babel/runtime": "^7.16.7",
     "@types/jsonwebtoken": "^8.5.6",
-    "@types/jwt-decode": "^2.2.1",
     "@types/qs": "^6.9.7",
     "axios": "^0.22.0",
     "faye": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,11 +1395,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jwt-decode@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
-  integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
-
 "@types/keyv@*":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.3.tgz#1c9aae32872ec1f20dcdaee89a9f3ba88f465e41"


### PR DESCRIPTION
https://www.npmjs.com/package/@types/jwt-decode
"This is a stub types definition. jwt-decode provides its own type definitions, so you do not need this installed."