### PR TITLE
Fix condition failing in browser

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -402,7 +402,7 @@ export class StreamClient<StreamFeedGenerics extends DefaultGenerics = DefaultGe
    * @return {string} current user agent
    */
   userAgent() {
-    if (process === undefined || process.env.PACKAGE_VERSION === undefined) {
+    if (typeof process === 'undefined' || process.env.PACKAGE_VERSION === undefined) {
       // eslint-disable-next-line
       return `stream-javascript-client-${this.node ? 'node' : 'browser'}-${require('../package.json').version}`;
     }


### PR DESCRIPTION
This bug was introduced in #572, meant to be a fix on its own. However, it doesn't take into account that `process === undefined` will fail in the browser.

<img width="462" alt="image" src="https://github.com/GetStream/stream-js/assets/1504938/977e24f9-2f26-4f26-b606-d660a4388edb">

Some bundlers will probably mitigate this, but when using Vite (or no bundler at all), the code will fail.