### PR TITLE
[FEEDS-0]chore: allow passing user_id in enrichment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -803,6 +803,7 @@ export class StreamClient<StreamFeedGenerics extends DefaultGenerics = DefaultGe
     foreignIDTimes?: ForeignIDTimes[];
     ids?: string[];
     reactions?: Record<string, boolean>;
+    user_id?: string;
   }) {
     const extraParams: { foreign_ids?: string; ids?: string; timestamps?: string } = {};
 

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -24,7 +24,7 @@ export type EnrichOptions = {
   withRecentReactions?: boolean;
 
   /**
-   * deprecated, use user_id
+   * @deprecated Use `user_id` instead.
    */
   withUserId?: string;
 };

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -22,6 +22,10 @@ export type EnrichOptions = {
   withOwnReactions?: boolean;
   withReactionCounts?: boolean;
   withRecentReactions?: boolean;
+
+  /**
+   * deprecated, use user_id
+   */
   withUserId?: string;
 };
 


### PR DESCRIPTION
This pull request includes changes to `src/client.ts` and `src/feed.ts` to add a new parameter and deprecate an old one. The most important changes are:


https://getstream.slack.com/archives/CSY9KAEFM/p1734948274931339