### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   browser:

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   browser:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   qa:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   qa:

--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -7,6 +7,10 @@ on:
         description: "The new version number with 'v' prefix. Example: v1.40.1"
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   init_release:
     name: 🚀 Create release PR

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   integration:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,6 +8,10 @@ on:
       - 'test/**'
       - '**.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   types:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   types:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **7** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
